### PR TITLE
[FEAT]: History 엔티티 및 Process 설계

### DIFF
--- a/src/main/java/umc/parasol/domain/history/domain/History.java
+++ b/src/main/java/umc/parasol/domain/history/domain/History.java
@@ -24,17 +24,17 @@ public class History extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @NotNull(message = "관련 멤버가 설정되어 있어야 합니다.")
     @JoinColumn(name = "member_id")
     private Member member;
     
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @NotNull(message = "관련 상점이 설정되어 있어야 합니다.")
     @JoinColumn(name = "shop_id")
     private Shop shop;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @NotNull(message = "관련 우산이 설정되어 있아야 합니다.")
     @JoinColumn(name = "umbrella_id")
     private Umbrella umbrella;

--- a/src/main/java/umc/parasol/domain/history/domain/History.java
+++ b/src/main/java/umc/parasol/domain/history/domain/History.java
@@ -1,4 +1,48 @@
 package umc.parasol.domain.history.domain;
 
-public class History {
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
+import umc.parasol.domain.common.BaseEntity;
+import umc.parasol.domain.member.domain.Member;
+import umc.parasol.domain.shop.domain.Shop;
+import umc.parasol.domain.umbrella.domain.Umbrella;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Where(clause = "status = 'ACTIVE'")
+public class History extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @NotNull(message = "관련 멤버가 설정되어 있어야 합니다.")
+    @JoinColumn(name = "member_id")
+    private Member member;
+    
+    @ManyToOne
+    @NotNull(message = "관련 상점이 설정되어 있어야 합니다.")
+    @JoinColumn(name = "shop_id")
+    private Shop shop;
+
+    @ManyToOne
+    @NotNull(message = "관련 우산이 설정되어 있아야 합니다.")
+    @JoinColumn(name = "umbrella_id")
+    private Umbrella umbrella;
+
+    @NotNull(message = "가격이 설정되어 있어야 합니다.")
+    private Long cost;
+    
+    @Enumerated(EnumType.STRING)
+    @NotNull(message = "절차가 설정되어 있어야 합니다.")
+    private Process process;
 }

--- a/src/main/java/umc/parasol/domain/history/domain/Process.java
+++ b/src/main/java/umc/parasol/domain/history/domain/Process.java
@@ -1,0 +1,5 @@
+package umc.parasol.domain.history.domain;
+
+public enum Process {
+    USE, CLEAR, DELAY
+}


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] History 엔티티 설계 
- [x] History 엔티티에 쓰일 Process 설계 

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- History
  - Member, Shop과 같이 필드가 많다고 판단해 `빌더 패턴`을 적용하였습니다.
  - History는 Member, Shop, Umbrella가 함께 M:N 관계로 이루어져 있는 브릿지 테이블입니다. 그렇기 때문에 이 요소들에 모두 `@NotNull`을 붙였고, 미충족 시의 메시지를 작성하였습니다. 또한, 가격을 무조건 작성하도록 cost에도 해당 어노테이션을 붙였습니다.
- Process
  - ERD에 작성했었던 returned를 뜻합니다. Process가 더 단어의 뜻에 적절하다고 생각되어 교체했습니다.
  - 정상적으로 우산을 사용중임을 나타내는 `USE`, 반납이 되어 과거의 기록으로 쌓여짐을 나타낸 `CLEAR`, 반납이 되지 않아 연체됨을 나타내는 `DELAY`로 구분하였습니다. 
## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->