### PR TITLE
[FEAT]: Image 엔티티 및 Type 설계

### DIFF
--- a/src/main/java/umc/parasol/domain/image/domain/Image.java
+++ b/src/main/java/umc/parasol/domain/image/domain/Image.java
@@ -1,0 +1,33 @@
+package umc.parasol.domain.image.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
+import umc.parasol.domain.common.BaseEntity;
+import umc.parasol.domain.shop.domain.Shop;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Where(clause = "status = 'ACTIVE'")
+public class Image extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank(message = "관련 파일 url이 설정되어 있어야 합니다.")
+    private String url;
+
+    @ManyToOne
+    @JoinColumn(name = "shop_id")
+    @NotNull(message = "관련 상점이 설정되어 있어야 합니다.")
+    private Shop shop;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull(message = "관련 타입이 설정되어 있어야 합니다.")
+    private Type type;
+}

--- a/src/main/java/umc/parasol/domain/image/domain/Image.java
+++ b/src/main/java/umc/parasol/domain/image/domain/Image.java
@@ -22,7 +22,7 @@ public class Image extends BaseEntity {
     @NotBlank(message = "관련 파일 url이 설정되어 있어야 합니다.")
     private String url;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "shop_id")
     @NotNull(message = "관련 상점이 설정되어 있어야 합니다.")
     private Shop shop;

--- a/src/main/java/umc/parasol/domain/image/domain/Type.java
+++ b/src/main/java/umc/parasol/domain/image/domain/Type.java
@@ -1,0 +1,5 @@
+package umc.parasol.domain.image.domain;
+
+public enum Type {
+    INSIDE, OUTSIDE
+}


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] Image 엔티티 설계
- [x] Image 엔티티에 쓰일 Type 설계

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- Image
  - 하나의 Shop에서는 여러 개의 Image들을 가질 수 있다고 판단했습니다. 따라서 참조된 Shop에 `@ManyToOne`을 붙였습니다.
  - 파일 경로를 나타내는 url에 `@NotBlank` 및 미충족 시의 메시지를 붙였고, 연결된 Shop에도 `@NotNull` 및 메시지를 붙였습니다.
- Type
  - 겉으로 보여지는 이미지인지, 내부 이미지인지 구분할 수 있겠다고 생각했습니다. 네이버 지도의 경우에도 특정 지점을 조회해보면 대표 사진이 하나 보이고 내부 이미지를 여러 개 가질 수 있는데, 이와 유사한 시스템이라고 판단했습니다.
  - 각각 `INSIDE`, `OUTSIDE`로 정의했습니다. 고객이 상점을 검색할 시 가장 먼저 보여질 이미지는 `INSIDE`에 해당될 것입니다.
  - Type 또한 반드시 가져야 한다고 생각해 `@NotNull` 및 미충족 시의 메시지를 붙였습니다.

## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
