### PR TITLE
[FIX]: dto 값 로드 이슈 해결, BaseEntity null값 문제 해결

### DIFF
--- a/src/main/java/umc/parasol/ParasolApplication.java
+++ b/src/main/java/umc/parasol/ParasolApplication.java
@@ -3,9 +3,11 @@ package umc.parasol;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import umc.parasol.global.config.YamlPropertySourceFactory;
 
 @SpringBootApplication
+@EnableJpaAuditing
 @PropertySource(value = {"classpath:database/application-database.yml"}, factory = YamlPropertySourceFactory.class)
 @PropertySource(value = {"classpath:auth/application-auth.yml"}, factory = YamlPropertySourceFactory.class)
 public class ParasolApplication {

--- a/src/main/java/umc/parasol/domain/auth/dto/SignUpReq.java
+++ b/src/main/java/umc/parasol/domain/auth/dto/SignUpReq.java
@@ -4,8 +4,10 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
 public class SignUpReq {
 


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 회원가입 dto null 값 이슈 해결
- [x] `BaseEntity` 값 저장 이슈 해결

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- 회원가입 시 dto (`SignUpReq`)의 값을 매핑하는 데 발생하는 문제를 해결했습니다.
- 객체 생성 시 `BaseEntity`의 `created_at`이 null로 저장되는 문제를 해결했습니다. 


## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
- 첫 번째 문제는 [이곳](https://7357.tistory.com/213)을 참고했습니다. `SignUpReq` 뿐 아니라 요청에 필요한 dto에는 모두 `@NoArgsConstructor`가 필요할 것 같습니다.
- 두 번째 문제는 [이곳](https://velog.io/@vpdls1511/BaseEntity-%EC%A0%81%EC%9A%A9-%EC%8B%9C-NULL%EA%B0%92-%EB%93%A4%EC%96%B4%EA%B0%90)을 참고했습니다.
