### PR TITLE
[FEAT]: 본인 인증 필드, Dto 추가

### DIFF
--- a/src/main/java/umc/parasol/domain/auth/dto/SignInReq.java
+++ b/src/main/java/umc/parasol/domain/auth/dto/SignInReq.java
@@ -8,7 +8,7 @@ import lombok.Data;
 @Data
 public class SignInReq {
 
-    @NotBlank
+    @NotBlank(message = "이메일을 입력해야 합니다.")
     @Email(message = "이메일 형식이어야 합니다.")
     private String email;
 

--- a/src/main/java/umc/parasol/domain/auth/dto/VerifyReq.java
+++ b/src/main/java/umc/parasol/domain/auth/dto/VerifyReq.java
@@ -1,0 +1,16 @@
+package umc.parasol.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Data;
+
+@Data
+public class VerifyReq {
+
+    @NotBlank(message = "이름을 입력해야 합니다.")
+    private String name;
+
+    @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "핸드폰 번호의 양식과 맞지 않습니다.")
+    private String phoneNumber;
+
+}

--- a/src/main/java/umc/parasol/domain/member/application/MemberService.java
+++ b/src/main/java/umc/parasol/domain/member/application/MemberService.java
@@ -1,4 +1,29 @@
 package umc.parasol.domain.member.application;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.parasol.domain.member.domain.repository.MemberRepository;
+import umc.parasol.domain.member.dto.UpdatePwReq;
+import umc.parasol.global.config.security.token.UserPrincipal;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    // 비밀번호 변경
+    public void updatePassword(UpdatePwReq updatePwReq) {
+        // 1. 현재 비밀번호, 새 비밀번호, 새 비밀번호 재입력 ok -> 변경
+        // 2. 인증 후 비밀번호 재설정
+
+
+    }
+
+    // 회원 탈퇴
+    public void deleteMember(UserPrincipal userPrincipal) {
+        // 미반납 우산이 있거나, 미납된 연체료가 있는 회원은 탈퇴가 불가 (예외처리)
+    }
 }

--- a/src/main/java/umc/parasol/domain/member/domain/Member.java
+++ b/src/main/java/umc/parasol/domain/member/domain/Member.java
@@ -21,9 +21,6 @@ public class Member extends BaseEntity {
     @Column(name = "member_id")
     private Long id;
 
-    //providerId로 대채
-    //private Long uuid;
-
     @Column(unique = true)
     private String nickname;
 
@@ -38,9 +35,6 @@ public class Member extends BaseEntity {
     @NotNull(message = "역할이 설정되어 있어야 합니다.")
     private Role role;
 
-    @NotNull(message = "인증 여부가 설정되어 있어야 합니다.")
-    private Boolean isVerified;
-
     @Enumerated(EnumType.STRING)
     private AuthRole authRole;
 
@@ -50,11 +44,20 @@ public class Member extends BaseEntity {
     @Column(unique = true)
     private String providerId;
 
+    // 인증 관련 필드
+    @NotNull(message = "인증 여부가 설정되어 있어야 합니다.")
+    private Boolean isVerified;
 
-    // @Setter 대신에 사용하는 업데이트 메소드 //
+    private String name;
+
+    private String phoneNumber;
+
+
+    // update 메서드
     public void updateNickname(String nickname){this.nickname = nickname;}
 
     public void updatePassword(String password){this.password = password;}
 
     public void updateIsVerified(Boolean isVerified) {this.isVerified = isVerified;}
+
 }

--- a/src/main/java/umc/parasol/domain/member/dto/UpdatePwReq.java
+++ b/src/main/java/umc/parasol/domain/member/dto/UpdatePwReq.java
@@ -1,0 +1,15 @@
+package umc.parasol.domain.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class UpdatePwReq {
+
+    @NotBlank(message = "현재 비밀번호를 입력해야 합니다.")
+    private String oldPw;
+
+    @NotBlank(message = "새 비밀번호를 입력해야 합니다.")
+    private String newPw;
+
+}


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 본인 인증 관련 Member 엔티티 필드를 추가 
- [x] 본인 인증 관련 Dto 추가
- [ ] 비밀번호 변경, 회원 탈퇴

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- 본인 인증 관련 필드를 Member 엔티티에 추가했습니다. `name`, `phoneNumber`
- 본인 인증 Dto를 만들었습니다. `name`, `phoneNumber`
- 회원가입 이후에 본인 인증을 진행하기 때문에 Entity에서는 `validation`하지 않습니다.
- `비밀번호 변경`은 회의 때 추가로 논의해야할 부분이 있어 추후 작업하겠습니다.
- `회원 탈퇴`는 미반납 우산, 미납 연체료 때문에 다른 엔티티와 엮여있는 부분이 있어 추후 작업하겠습니다. 


## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
- 
