### PR TITLE
문자 인증 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-
+	implementation 'net.nurigo:sdk:4.3.0'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'

--- a/src/main/java/umc/parasol/domain/member/domain/Member.java
+++ b/src/main/java/umc/parasol/domain/member/domain/Member.java
@@ -52,7 +52,6 @@ public class Member extends BaseEntity {
 
     private String phoneNumber;
 
-
     // update 메서드
     public void updateNickname(String nickname){this.nickname = nickname;}
 
@@ -60,4 +59,11 @@ public class Member extends BaseEntity {
 
     public void updateIsVerified(Boolean isVerified) {this.isVerified = isVerified;}
 
+    public void updatePhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/umc/parasol/domain/member/domain/repository/MemberRepository.java
+++ b/src/main/java/umc/parasol/domain/member/domain/repository/MemberRepository.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    Optional<Member> findByPhoneNumber(String phoneNumber);
     Optional<Member> findByEmail(String email);
 
     Boolean existsByEmail(String email);

--- a/src/main/java/umc/parasol/domain/verify/application/VerifyService.java
+++ b/src/main/java/umc/parasol/domain/verify/application/VerifyService.java
@@ -47,11 +47,18 @@ public class VerifyService {
         int code = generateVerifyCode();
         Member findMember = findMemberByEmail(verifyReq.getEmail());
         updateMemberNumberAndName(verifyReq, findMember);
+        removePreviousVerifies(findMember);
         Verify newVerify = createVerify(code, findMember);
         verifyRepository.save(newVerify);
         sendMessage(verifyReq, code);
 
         return new ApiResponse(true, newVerify);
+    }
+
+    private void removePreviousVerifies(Member findMember) {
+        Verify findVerify = verifyRepository.findByMember(findMember);
+        if (findVerify != null)
+            verifyRepository.delete(findVerify);
     }
 
     private static Verify createVerify(int code, Member findMember) {

--- a/src/main/java/umc/parasol/domain/verify/application/VerifyService.java
+++ b/src/main/java/umc/parasol/domain/verify/application/VerifyService.java
@@ -1,0 +1,104 @@
+package umc.parasol.domain.verify.application;
+
+import lombok.RequiredArgsConstructor;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.parasol.domain.member.domain.Member;
+import umc.parasol.domain.member.domain.repository.MemberRepository;
+import umc.parasol.domain.verify.domain.Verify;
+import umc.parasol.domain.verify.domain.repository.VerifyRepository;
+import umc.parasol.domain.verify.dto.CheckReq;
+import umc.parasol.domain.verify.dto.VerifyReq;
+import umc.parasol.global.payload.ApiResponse;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+
+import static net.nurigo.sdk.NurigoApp.INSTANCE;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class VerifyService {
+
+    private final MemberRepository memberRepository;
+
+    @Value("${message.api-key}")
+    private String MessageApiKey;
+
+    @Value("${message.secret-key}")
+    private String MessageSecretKey;
+
+    @Value("${message.domain}")
+    private String MessageDomain;
+
+    @Value("${message.host}")
+    private String MessageHostNumber;
+    private final VerifyRepository verifyRepository;
+
+    // 문자 인증
+    @Transactional
+    public ApiResponse verify(VerifyReq verifyReq) {
+        int code = generateVerifyCode();
+
+        Member findMember = findMemberByEmail(verifyReq.getEmail());
+        findMember.updatePhoneNumber(verifyReq.getPhoneNumber());
+        findMember.updateName(verifyReq.getName());
+
+        Verify newVerify = Verify.builder()
+                .code(code)
+                .member(findMember)
+                .build();
+
+        verifyRepository.save(newVerify);
+        DefaultMessageService messageService = INSTANCE.initialize(MessageApiKey, MessageSecretKey, MessageDomain);
+        Message newMessage = generateVerifyMessage(verifyReq.getPhoneNumber(), code);
+        messageService.sendOne(new SingleMessageSendingRequest(newMessage));
+
+        return new ApiResponse(true, newVerify);
+    }
+
+    // 문자 인증 확인
+    @Transactional
+    public ApiResponse check(CheckReq checkReq) {
+        Verify findVerify = verifyRepository.findByCode(checkReq.getCode())
+                .orElseThrow(() -> new IllegalArgumentException("코드가 일치하지 않습니다."));
+        LocalDateTime requestTime = LocalDateTime.now();
+        if (findVerify.checkExpiration(requestTime)) {
+            verifyRepository.delete(findVerify);
+            throw new IllegalStateException("인증 시간이 만료되었습니다.");
+        }
+
+        Member findMember = findVerify.getMember();
+        findMember.updateIsVerified(true);
+
+        verifyRepository.delete(findVerify);
+
+        return new ApiResponse(true, "인증 완료");
+    }
+
+    private Member findMemberByEmail(String email) {
+        return memberRepository.findByEmail(email).orElseThrow(
+                () -> new UsernameNotFoundException("유저 정보를 찾을 수 없습니다."));
+    }
+
+    // 문자 인증 코드 생성
+    private int generateVerifyCode() {
+        return new Random().nextInt(999999 - 10000 + 1) + 100000;
+    }
+
+    // 문자 생성
+    private Message generateVerifyMessage(String number, int code) {
+        Message newMessage = new Message();
+        newMessage.setFrom(MessageHostNumber);
+        newMessage.setTo(number);
+        newMessage.setText("[Parasol] 인증 번호는 " + code + " 입니다.");
+
+        return newMessage;
+    }
+}

--- a/src/main/java/umc/parasol/domain/verify/application/VerifyService.java
+++ b/src/main/java/umc/parasol/domain/verify/application/VerifyService.java
@@ -56,7 +56,7 @@ public class VerifyService {
     }
 
     private void removePreviousVerifies(Member findMember) {
-        Verify findVerify = verifyRepository.findByMember(findMember);
+        Verify findVerify = verifyRepository.findByMemberId(findMember.getId());
         if (findVerify != null)
             verifyRepository.delete(findVerify);
     }

--- a/src/main/java/umc/parasol/domain/verify/domain/Verify.java
+++ b/src/main/java/umc/parasol/domain/verify/domain/Verify.java
@@ -1,0 +1,37 @@
+package umc.parasol.domain.verify.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
+import umc.parasol.domain.common.BaseEntity;
+import umc.parasol.domain.member.domain.Member;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Where(clause = "status = 'ACTIVE'")
+public class Verify extends BaseEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "verify_id")
+    private Long id;
+
+    private Integer code;
+
+    @OneToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder.Default
+    private LocalDateTime expirationTime = LocalDateTime.now().plusMinutes(3);
+
+    public boolean checkExpiration(LocalDateTime now) {
+        return now.isAfter(expirationTime);
+    }
+}

--- a/src/main/java/umc/parasol/domain/verify/domain/repository/VerifyRepository.java
+++ b/src/main/java/umc/parasol/domain/verify/domain/repository/VerifyRepository.java
@@ -1,12 +1,11 @@
 package umc.parasol.domain.verify.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import umc.parasol.domain.member.domain.Member;
 import umc.parasol.domain.verify.domain.Verify;
 
 import java.util.Optional;
 
 public interface VerifyRepository extends JpaRepository<Verify, Long> {
     Optional<Verify> findByCode(int code);
-    Verify findByMember(Member member);
+    Verify findByMemberId(Long memberId);
 }

--- a/src/main/java/umc/parasol/domain/verify/domain/repository/VerifyRepository.java
+++ b/src/main/java/umc/parasol/domain/verify/domain/repository/VerifyRepository.java
@@ -1,0 +1,10 @@
+package umc.parasol.domain.verify.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.parasol.domain.verify.domain.Verify;
+
+import java.util.Optional;
+
+public interface VerifyRepository extends JpaRepository<Verify, Long> {
+    Optional<Verify> findByCode(int code);
+}

--- a/src/main/java/umc/parasol/domain/verify/domain/repository/VerifyRepository.java
+++ b/src/main/java/umc/parasol/domain/verify/domain/repository/VerifyRepository.java
@@ -1,10 +1,12 @@
 package umc.parasol.domain.verify.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import umc.parasol.domain.member.domain.Member;
 import umc.parasol.domain.verify.domain.Verify;
 
 import java.util.Optional;
 
 public interface VerifyRepository extends JpaRepository<Verify, Long> {
     Optional<Verify> findByCode(int code);
+    Verify findByMember(Member member);
 }

--- a/src/main/java/umc/parasol/domain/verify/dto/CheckReq.java
+++ b/src/main/java/umc/parasol/domain/verify/dto/CheckReq.java
@@ -1,0 +1,11 @@
+package umc.parasol.domain.verify.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class CheckReq {
+    private int code;
+    private String phoneNumber;
+}

--- a/src/main/java/umc/parasol/domain/verify/dto/VerifyReq.java
+++ b/src/main/java/umc/parasol/domain/verify/dto/VerifyReq.java
@@ -1,5 +1,6 @@
-package umc.parasol.domain.auth.dto;
+package umc.parasol.domain.verify.dto;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Data;
@@ -9,6 +10,10 @@ public class VerifyReq {
 
     @NotBlank(message = "이름을 입력해야 합니다.")
     private String name;
+
+    @NotBlank(message = "관련 이메일이 설정되어 있어야 합니다.")
+    @Email(message = "이메일 형식이어야 합니다.")
+    private String email;
 
     @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "핸드폰 번호의 양식과 맞지 않습니다.")
     private String phoneNumber;

--- a/src/main/java/umc/parasol/domain/verify/presentation/VerifyController.java
+++ b/src/main/java/umc/parasol/domain/verify/presentation/VerifyController.java
@@ -34,7 +34,7 @@ public class VerifyController {
     public ResponseEntity<?> check(@Valid @RequestBody CheckReq checkReq) {
         try {
             return ResponseEntity.ok(verifyService.check(checkReq));
-        } catch (IllegalArgumentException | IllegalStateException e) {
+        } catch (IllegalArgumentException | IllegalStateException | UsernameNotFoundException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
     }

--- a/src/main/java/umc/parasol/domain/verify/presentation/VerifyController.java
+++ b/src/main/java/umc/parasol/domain/verify/presentation/VerifyController.java
@@ -1,0 +1,41 @@
+package umc.parasol.domain.verify.presentation;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.parasol.domain.verify.application.VerifyService;
+import umc.parasol.domain.verify.dto.CheckReq;
+import umc.parasol.domain.verify.dto.VerifyReq;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/verify")
+public class VerifyController {
+
+    private final VerifyService verifyService;
+
+    // 문자 인증
+    @PostMapping()
+    public ResponseEntity<?> verify(@Valid @RequestBody VerifyReq verifyReq) {
+        try {
+            return ResponseEntity.ok(verifyService.verify(verifyReq));
+        } catch (UsernameNotFoundException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+    // 문자 인증 응답
+    @PostMapping("/check")
+    public ResponseEntity<?> check(@Valid @RequestBody CheckReq checkReq) {
+        try {
+            return ResponseEntity.ok(verifyService.check(checkReq));
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/umc/parasol/global/config/security/SecurityConfig.java
+++ b/src/main/java/umc/parasol/global/config/security/SecurityConfig.java
@@ -89,6 +89,8 @@ public class SecurityConfig {
                         .permitAll()
                     .requestMatchers("/auth/**")
                         .permitAll()
+                    .requestMatchers("/verify/**")
+                        .permitAll()
                     .anyRequest()
                         .authenticated()
                     .and()


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 문자 인증을 위한 Verify 엔티티 설계 
- [x] 문자 코드 불일치 검증 구현
- [x] 문자 코드 확인 요청 만료 검증 구현  
- [x] 문자 코드 검증 추가 (전화번호 활용)
- [x] 약간의 리팩터링 작업 
## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- [coolsms](https://docs.coolsms.co.kr/development-kits/java)를 활용해 문자 인증 기능을 구현하였습니다.
- 문자 인증은 회원가입, 비밀번호 찾기 등 다양한 때에 활용될 수 있을 것 같다고 판단하여 문자 인증을 위한 Verify 엔티티를 별도로 설계하였습니다.
- 처음에 문자 인증을 하기 위해서는 `/verify`에서 name, email, phoneNumber를 담아 요청해야 합니다. 이때 email을 활용하여 요청하고자 하는 멤버를 식별합니다. 그리고 이때 해당 멤버의 name과 phoneNumber가 업데이트 됩니다.
  - Verify는 Member와 1:1 관계입니다. 인증 후에 자동으로 Verify가 삭제되기 때문입니다.
- 문자 인증 요청을 보내면 6자리 난수가 생성되고, 데이터베이스에도 Verify 엔티티가 생성됩니다. Verify의 만료 시간은 생성 시점 후 3분 뒤로 설정하였습니다.
- 문자 인증 확인 요청을 하기 위해서는 `/verify/check`에서 code와 phoneNumber를 담아 요청합니다. 해당 코드를 가진 Verify 엔티티가 있는지 검사하며, 해당 Verify 엔티티로부터 관련된 멤버를 조회한 뒤 phoneNumber가 같은지 2차 검증을 진행합니다. 만약 해당 멤버가 없거나 해당 멤버의 인증 여부가 이미 true로 설정되어 있다면 에러를 반환하도록 하였습니다.
## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
- [SMS 인증 기능 프로그램](https://coolsms.co.kr/)
- [Spring에서 핸드폰으로 인증문자 보내기](https://velog.io/@hwarkhada/%EB%AC%B8%EC%9E%90%EB%A1%9C-%EC%9D%B8%EC%A6%9D%EB%B2%88%ED%98%B8-%EB%B3%B4%EB%82%B4%EA%B8%B0)
