### PR TITLE
[FEAT]: 사장님 회원가입 API 개발

### DIFF
--- a/src/main/java/umc/parasol/domain/auth/dto/SignUpCustomerReq.java
+++ b/src/main/java/umc/parasol/domain/auth/dto/SignUpCustomerReq.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class SignUpReq {
+public class SignUpCustomerReq {
 
     @NotBlank(message = "이름을 입력해야 합니다.")
     private String nickname;

--- a/src/main/java/umc/parasol/domain/auth/dto/SignUpOwnerReq.java
+++ b/src/main/java/umc/parasol/domain/auth/dto/SignUpOwnerReq.java
@@ -1,0 +1,38 @@
+package umc.parasol.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SignUpOwnerReq {
+
+    @NotBlank(message = "이름을 입력해야 합니다.")
+    private String nickname;
+
+    @NotBlank
+    @Email(message = "이메일 형식이어야 합니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력해야 합니다.")
+    private String password;
+
+    @NotBlank(message = "매장명을 입력해야 합니다.")
+    private String shopName;
+
+    @NotNull(message = "위도를 입력해야 합니다.")
+    private BigDecimal latitude;
+
+    @NotNull(message = "경도를 입력해야 합니다.")
+    private BigDecimal longitude;
+
+    @NotBlank(message = "도로명 주소를 입력해야 합니다.")
+    private String roadNameAddress;
+}

--- a/src/main/java/umc/parasol/domain/auth/presentation/AuthController.java
+++ b/src/main/java/umc/parasol/domain/auth/presentation/AuthController.java
@@ -10,10 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import umc.parasol.domain.auth.application.AuthSignService;
 import umc.parasol.domain.auth.application.AuthTokenService;
-import umc.parasol.domain.auth.dto.AuthRes;
-import umc.parasol.domain.auth.dto.RefreshTokenReq;
-import umc.parasol.domain.auth.dto.SignInReq;
-import umc.parasol.domain.auth.dto.SignUpReq;
+import umc.parasol.domain.auth.dto.*;
 import umc.parasol.global.config.security.token.CurrentUser;
 import umc.parasol.global.config.security.token.UserPrincipal;
 import umc.parasol.global.payload.ApiResponse;
@@ -30,14 +27,31 @@ public class AuthController {
 
     private final AuthTokenService authTokenService;
 
-    //회원가입
-    @PostMapping("/sign-up")
-    public ResponseEntity<?> signUp(
-            @Valid @RequestBody SignUpReq signUpReq) {
+    //회원가입 (일반 사용자-customer)
+    @PostMapping("/sign-up/customer")
+    public ResponseEntity<?> signUpCustomer(
+            @Valid @RequestBody SignUpCustomerReq signUpReq) {
 
         URI location = ServletUriComponentsBuilder
                 .fromCurrentContextPath().path("/users")
-                .buildAndExpand(authService.signUp(signUpReq)).toUri();
+                .buildAndExpand(authService.signUpCustomer(signUpReq)).toUri();
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information(Message.builder().message("회원가입에 성공했습니다").build())
+                .build();
+
+        return ResponseEntity.created(location).body(apiResponse);
+    }
+
+    //회원가입 (사장님-owner)
+    @PostMapping("/sign-up/owner")
+    public ResponseEntity<?> signUpOwner(
+            @Valid @RequestBody SignUpOwnerReq signUpOwnerReq) {
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentContextPath().path("/users")
+                .buildAndExpand(authService.signUpOwner(signUpOwnerReq)).toUri();
 
         ApiResponse apiResponse = ApiResponse.builder()
                 .check(true)

--- a/src/main/java/umc/parasol/domain/member/domain/Member.java
+++ b/src/main/java/umc/parasol/domain/member/domain/Member.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.hibernate.annotations.Where;
 import umc.parasol.domain.common.BaseEntity;
+import umc.parasol.domain.shop.domain.Shop;
 
 @Entity
 @Builder
@@ -51,6 +52,10 @@ public class Member extends BaseEntity {
     private String name;
 
     private String phoneNumber;
+
+    @OneToOne
+    @JoinColumn(name = "shop_id")
+    private Shop shop;
 
     // update 메서드
     public void updateNickname(String nickname){this.nickname = nickname;}

--- a/src/main/java/umc/parasol/domain/shop/domain/Shop.java
+++ b/src/main/java/umc/parasol/domain/shop/domain/Shop.java
@@ -2,6 +2,7 @@ package umc.parasol.domain.shop.domain;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,14 +25,21 @@ public class Shop extends BaseEntity {
     @Column(name = "shop_id")
     private Long id;
 
-    @NotBlank(message = "위도가 설정되어 있어야 합니다.")
+    @NotNull(message = "위도가 설정되어 있어야 합니다.")
     private BigDecimal latitude;
 
-    @NotBlank(message = "경도가 설정되어 있어야 합니다.")
+    @NotNull(message = "경도가 설정되어 있어야 합니다.")
     private BigDecimal longitude;
+
+    @NotBlank(message = "도로명 주소를 입력해야 합니다.")
+    private String roadNameAddress;
 
     @NotBlank(message = "지점 이름이 설정되어 있어야 합니다.")
     private String name;
 
     private String description;
+
+    private String openTime;
+
+    private String closeTime;
 }

--- a/src/main/java/umc/parasol/domain/shop/domain/repository/ShopRepository.java
+++ b/src/main/java/umc/parasol/domain/shop/domain/repository/ShopRepository.java
@@ -1,4 +1,9 @@
 package umc.parasol.domain.shop.domain.repository;
 
-public interface ShopRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import umc.parasol.domain.shop.domain.Shop;
+
+@Repository
+public interface ShopRepository extends JpaRepository<Shop, Long> {
 }


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 사장님 회원가입 API 개발 
- [x] Shop 엔티티 - `roadNameAddress`, `openTime`, `closeTime` 필드 추가 

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- Shop 필드 중 위도, 경도의 타입이 `BigDecimal`인데, @NotBlank 어노테이션은 String 타입에만 사용 가능하다고 하여 @NotNull 어노테이션으로 변경했습니다.
- 사장님 회원가입 로직 = 매장 객체 생성 -> 멤버에 매장 넣고 객체 생성
- Shop 필드 중 오픈시간, 마감시간은 매장 객체 생성 후 따로 설정 할 예정이기 때문에 validation 어노테이션 걸지 않았습니다.
- `Member와 Shop 1:1 관계`를 맺었습니다. Member를 주 테이블로 보고 Member -> Shop 단방향으로 연결했습니다.


## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
- [1:1 관계](https://ict-nroo.tistory.com/126)
