### PR TITLE
[FEAT] 점주 Shop 사진 업로드 기능 추가

### DIFF
--- a/src/main/java/umc/parasol/domain/image/application/ImageService.java
+++ b/src/main/java/umc/parasol/domain/image/application/ImageService.java
@@ -1,0 +1,68 @@
+package umc.parasol.domain.image.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import umc.parasol.domain.image.domain.Image;
+import umc.parasol.domain.image.domain.repository.ImageRepository;
+import umc.parasol.domain.image.dto.ImageRes;
+import umc.parasol.domain.member.domain.Member;
+import umc.parasol.domain.member.domain.repository.MemberRepository;
+import umc.parasol.domain.shop.domain.Shop;
+import umc.parasol.domain.shop.domain.repository.ShopRepository;
+import umc.parasol.global.config.security.token.UserPrincipal;
+import umc.parasol.global.infrastructure.S3Uploader;
+import umc.parasol.global.payload.ApiResponse;
+
+import java.io.IOException;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ImageService {
+    private final ImageRepository imageRepository;
+    private final ShopRepository shopRepository;
+    private final MemberRepository memberRepository;
+    private final S3Uploader s3Uploader;
+
+    public ApiResponse upload(Long shopId, MultipartFile file, UserPrincipal user) throws Exception {
+        validShopAndIsOwner(shopId, user);
+        String storedFileUrl = s3Uploader.outerUpload(file, "shop", user);
+        Image storedImage = createImageEntity(storedFileUrl, shopId);
+
+        return ApiResponse.builder()
+                .check(true)
+                .information(new ImageRes(storedImage.getId(), storedImage.getUrl()))
+                .build();
+    }
+
+    private void validShopAndIsOwner(Long shopId, UserPrincipal user) {
+        Shop targetShop = getShop(shopId);
+        Member owner = memberRepository.findById(user.getId()).orElseThrow(
+                () -> new IllegalStateException("해당 member가 존재하지 않습니다.")
+        );
+        if (targetShop != owner.getShop()) {
+            throw new IllegalStateException("해당 shop의 owner가 아닙니다.");
+        }
+    }
+
+    private Image createImageEntity(String url, Long shopId) {
+        deleteDuplicatedImage(url);
+        Shop targetShop = getShop(shopId);
+        return imageRepository.save(new Image(url, targetShop));
+    }
+
+    private void deleteDuplicatedImage(String url) {
+        Image existedImage = imageRepository.findByUrl(url);
+        if (existedImage != null) {
+            imageRepository.delete(existedImage);
+        }
+    }
+
+    private Shop getShop(Long shopId) {
+        return shopRepository.findById(shopId).orElseThrow(
+                () -> new IllegalStateException("해당 shop이 존재하지 않습니다.")
+        );
+    }
+}

--- a/src/main/java/umc/parasol/domain/image/domain/Image.java
+++ b/src/main/java/umc/parasol/domain/image/domain/Image.java
@@ -17,6 +17,7 @@ public class Image extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id")
     private Long id;
 
     @NotBlank(message = "관련 파일 url이 설정되어 있어야 합니다.")
@@ -27,7 +28,8 @@ public class Image extends BaseEntity {
     @NotNull(message = "관련 상점이 설정되어 있어야 합니다.")
     private Shop shop;
 
-    @Enumerated(EnumType.STRING)
-    @NotNull(message = "관련 타입이 설정되어 있어야 합니다.")
-    private Type type;
+    public Image(String url, Shop shop) {
+        this.url = url;
+        this.shop = shop;
+    }
 }

--- a/src/main/java/umc/parasol/domain/image/domain/Type.java
+++ b/src/main/java/umc/parasol/domain/image/domain/Type.java
@@ -1,5 +1,5 @@
 package umc.parasol.domain.image.domain;
 
 public enum Type {
-    INSIDE, OUTSIDE
+    OUTSIDE
 }

--- a/src/main/java/umc/parasol/domain/image/domain/repository/ImageRepository.java
+++ b/src/main/java/umc/parasol/domain/image/domain/repository/ImageRepository.java
@@ -1,0 +1,8 @@
+package umc.parasol.domain.image.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.parasol.domain.image.domain.Image;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+    Image findByUrl(String url);
+}

--- a/src/main/java/umc/parasol/domain/image/dto/ImageRes.java
+++ b/src/main/java/umc/parasol/domain/image/dto/ImageRes.java
@@ -1,0 +1,15 @@
+package umc.parasol.domain.image.dto;
+
+import lombok.Data;
+
+@Data
+public class ImageRes {
+
+    private Long id;
+    private String url;
+
+    public ImageRes(Long id, String url) {
+        this.id = id;
+        this.url = url;
+    }
+}

--- a/src/main/java/umc/parasol/domain/member/domain/Member.java
+++ b/src/main/java/umc/parasol/domain/member/domain/Member.java
@@ -53,7 +53,7 @@ public class Member extends BaseEntity {
 
     private String phoneNumber;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "shop_id")
     private Shop shop;
 

--- a/src/main/java/umc/parasol/domain/shop/presentation/ShopController.java
+++ b/src/main/java/umc/parasol/domain/shop/presentation/ShopController.java
@@ -1,8 +1,11 @@
 package umc.parasol.domain.shop.presentation;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import umc.parasol.domain.image.application.ImageService;
 import umc.parasol.domain.shop.application.ShopService;
 import umc.parasol.domain.shop.dto.ShopListRes;
 import umc.parasol.domain.shop.dto.UpdateUmbrellaReq;
@@ -18,6 +21,7 @@ import java.util.List;
 public class ShopController {
 
     private final ShopService shopService;
+    private final ImageService imageService;
 
     // 매장 조회
     @GetMapping
@@ -49,5 +53,16 @@ public class ShopController {
                 .build();
 
         return ResponseEntity.ok(apiResponse);
+    }
+
+    // 매장 사진 업로드
+    @PostMapping(value = "/{id}/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> imageUpload(@RequestParam(value = "image")
+                                         MultipartFile file, @PathVariable Long id, @CurrentUser UserPrincipal user) {
+        try {
+            return ResponseEntity.ok(imageService.upload(id, file, user));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
     }
 }

--- a/src/main/java/umc/parasol/global/config/S3Config.java
+++ b/src/main/java/umc/parasol/global/config/S3Config.java
@@ -1,8 +1,36 @@
 package umc.parasol.global.config;
 
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 // application/properties 파일에 작성한 값들을 읽어와서 AmazonS3Client 객체를 만들어 Bean으로 주입
 @Configuration
 public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
 }

--- a/src/main/java/umc/parasol/global/infrastructure/S3Uploader.java
+++ b/src/main/java/umc/parasol/global/infrastructure/S3Uploader.java
@@ -1,7 +1,9 @@
 package umc.parasol.global.infrastructure;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -9,6 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import umc.parasol.global.config.security.token.UserPrincipal;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -21,54 +24,54 @@ import java.util.Optional;
 @Service
 public class S3Uploader {
 
+    private final AmazonS3Client amazonS3Client;
 
-    // AmazonS3Client -> AmazonS3
-//    private final AmazonS3 amazonS3Client;
-//
-//    @Value("${cloud.aws.s3.bucket}")
-//    private String bucket;
-//
-//    // MultipartFile -> File 전환 후 S3 버킷에 업로드
-//    public String upload(MultipartFile multipartFile, String dirName) throws IOException {
-//        File uploadFile = convert(multipartFile)
-//                .orElseThrow(() -> new IllegalArgumentException("MultipartFile -> File 전환 실패"));
-//        return upload(uploadFile, dirName);
-//    }
-//
-//    private String upload(File uploadFile, String dirName) {
-//        String fileName = dirName + "/" + uploadFile.getName();
-//        String uploadImageUrl = putS3(uploadFile, fileName);
-//
-//        removeNewFile(uploadFile);  // 로컬에 생성된 File 삭제 (MultipartFile -> File 전환 하며 로컬에 파일 생성됨)
-//
-//        return uploadImageUrl;      // 업로드된 파일의 S3 URL 주소 반환
-//    }
-//
-//    private String putS3(File uploadFile, String fileName) {
-//        amazonS3Client.putObject(
-//                new PutObjectRequest(bucket, fileName, uploadFile)
-//                        .withCannedAcl(CannedAccessControlList.PublicRead)	// PublicRead 권한으로 업로드 됨
-//        );
-//        return amazonS3Client.getUrl(bucket, fileName).toString();
-//    }
-//
-//    private void removeNewFile(File targetFile) {
-//        if(targetFile.delete()) {
-//            log.info("파일이 삭제되었습니다.");
-//        }else {
-//            log.info("파일이 삭제되지 못했습니다.");
-//        }
-//    }
-//
-//    private Optional<File> convert(MultipartFile file) throws  IOException {
-//        File convertFile = new File(file.getOriginalFilename());
-//        if(convertFile.createNewFile()) {
-//            try (FileOutputStream fos = new FileOutputStream(convertFile)) {
-//                fos.write(file.getBytes());
-//            }
-//            return Optional.of(convertFile);
-//        }
-//        return Optional.empty();
-//    }
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
 
+    public String outerUpload(MultipartFile multipartFile, String dirName, UserPrincipal user) throws IOException {
+        File uploadFile = convert(multipartFile, user)
+                .orElseThrow(() -> new IllegalArgumentException("MultipartFile -> File 전환 실패"));
+        return innerUpload(uploadFile, dirName);
+    }
+
+    private String innerUpload(File uploadFile, String dirName) {
+        String fileName = dirName + "/" + uploadFile.getName();
+        String uploadImageUrl = putS3(uploadFile, fileName);
+        removeNewFile(uploadFile);
+        return uploadImageUrl;
+    }
+
+    private String putS3(File uploadFile, String fileName) {
+        amazonS3Client.putObject(
+                new PutObjectRequest(bucket, fileName, uploadFile)
+                        .withCannedAcl(CannedAccessControlList.PublicRead)
+        );
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+    private void removeNewFile(File targetFile) {
+        if (targetFile.delete()) {
+            log.info("파일이 삭제되었습니다.");
+        } else {
+            log.info("파일이 삭제되지 못했습니다.");
+        }
+    }
+
+    private Optional<File> convert(MultipartFile file, UserPrincipal user) throws IOException {
+        File convertFile = new File(user.getId() + "_" + file.getOriginalFilename());
+        if (convertFile.createNewFile()) {
+            try (FileOutputStream fos = new FileOutputStream(convertFile)) {
+                fos.write(file.getBytes());
+            }
+            return Optional.of(convertFile);
+        }
+        return Optional.empty();
+    }
+
+    /*
+    private void deleteS3ObjectIfExisted(String url) {
+        amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, url));
+    }
+     */
 }


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] enum 타입인 Type의 값을 `OUTSIDE`만 있도록 변경하였습니다. 매장의 바깥 부분에 관련된 사진들만 보여진다고 설정했습니다. 
- [x] 사진이 저장될 시 응답으로는 해당 사진의 id, 사진이 저장된 S3 경로를 리턴합니다.
- [x] Member가 가지고 있는 Shop을 Lazy Loading 하도록 변경했습니다.

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- 사진의 최대 사이즈는 1MB로 설정하였습니다.
- 업로드가 되기 전에 현재 로그인 한 점주와 Shop의 관계가 올바른지 검증하는 `validShopAndIsOwner` 로직을 두었습니다.
- 현재 저장된 사진과 완전히 같은 사진이 있을 시 Image 엔티티를 없애는 `deleteDuplicatedImage` 로직을 두었습니다.
- 사진이 저장될 시 이름을 `{현재 로그인 한 점주의 id}_{사진의 이름}.{확장자}`로 저장되도록 하였습니다. 

## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
- [스프링 사진 용량 설정법](https://velog.io/@jinho_pca/Spring-Boot-%ED%8C%8C%EC%9D%BC-%EC%97%85%EB%A1%9C%EB%93%9C-%EC%9A%A9%EB%9F%89%EC%A0%9C%ED%95%9C-%EC%84%A4%EC%A0%95)
- [파일 업로드 크기 제한 exception](https://www.inflearn.com/questions/810872/%ED%8C%8C%EC%9D%BC-%EC%97%85%EB%A1%9C%EB%93%9C-%ED%81%AC%EA%B8%B0-%EC%A0%9C%ED%95%9C-exception%EC%97%90-%EB%8C%80%ED%95%B4-%EC%A7%88%EB%AC%B8%EB%93%9C%EB%A6%BD%EB%8B%88%EB%8B%A4)
- [[SpringBoot] AWS S3로 이미지 업로드하기](https://velog.io/@chaeri93/SpringBoot-AWS-S3%EB%A1%9C-%EC%9D%B4%EB%AF%B8%EC%A7%80-%EC%97%85%EB%A1%9C%EB%93%9C%ED%95%98%EA%B8%B0)
