### PR TITLE
[FEAT] 비밀번호 변경 로직 추가

### DIFF
--- a/src/main/java/umc/parasol/domain/auth/dto/RefreshTokenReq.java
+++ b/src/main/java/umc/parasol/domain/auth/dto/RefreshTokenReq.java
@@ -9,4 +9,7 @@ public class RefreshTokenReq {
     @NotBlank(message = "Refersh Token을 입력해야 합니다.")
     private String refreshToken;
 
+    public RefreshTokenReq(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/umc/parasol/domain/member/application/MemberService.java
+++ b/src/main/java/umc/parasol/domain/member/application/MemberService.java
@@ -6,7 +6,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.parasol.domain.auth.application.AuthSignService;
-import umc.parasol.domain.auth.domain.repository.TokenRepository;
 import umc.parasol.domain.auth.dto.RefreshTokenReq;
 import umc.parasol.domain.member.domain.Member;
 import umc.parasol.domain.member.domain.repository.MemberRepository;
@@ -22,7 +21,6 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final AuthSignService authSignService;
-    private final TokenRepository tokenRepository;
 
     // 비밀번호 변경
     @Transactional

--- a/src/main/java/umc/parasol/domain/member/application/MemberService.java
+++ b/src/main/java/umc/parasol/domain/member/application/MemberService.java
@@ -1,11 +1,18 @@
 package umc.parasol.domain.member.application;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCrypt;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.parasol.domain.auth.application.AuthSignService;
+import umc.parasol.domain.auth.domain.repository.TokenRepository;
+import umc.parasol.domain.auth.dto.RefreshTokenReq;
+import umc.parasol.domain.member.domain.Member;
 import umc.parasol.domain.member.domain.repository.MemberRepository;
 import umc.parasol.domain.member.dto.UpdatePwReq;
 import umc.parasol.global.config.security.token.UserPrincipal;
+import umc.parasol.global.payload.ApiResponse;
 
 @Service
 @RequiredArgsConstructor
@@ -13,17 +20,40 @@ import umc.parasol.global.config.security.token.UserPrincipal;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthSignService authSignService;
+    private final TokenRepository tokenRepository;
 
     // 비밀번호 변경
-    public void updatePassword(UpdatePwReq updatePwReq) {
+    @Transactional
+    public ApiResponse updatePassword(UpdatePwReq updatePwReq, UserPrincipal user) {
         // 1. 현재 비밀번호, 새 비밀번호, 새 비밀번호 재입력 ok -> 변경
         // 2. 인증 후 비밀번호 재설정
+        String oldPw = updatePwReq.getOldPw();
+        validateOriginPassword(oldPw, user.getPassword());
 
+        String newPw = updatePwReq.getNewPw();
+        Member findMember = memberRepository.findById(user.getId()).orElseThrow(
+                () -> new IllegalStateException("해당 member가 없습니다.")
+        );
 
+        findMember.updatePassword(passwordEncoder.encode(newPw));
+
+        authSignService.signOut(new RefreshTokenReq(updatePwReq.getRefreshToken())); // 로그아웃 처리
+
+        return ApiResponse.builder()
+                .check(true)
+                .information("비밀번호 변경 완료")
+                .build();
     }
 
     // 회원 탈퇴
     public void deleteMember(UserPrincipal userPrincipal) {
         // 미반납 우산이 있거나, 미납된 연체료가 있는 회원은 탈퇴가 불가 (예외처리)
+    }
+
+    private void validateOriginPassword(String checkPassword, String password) {
+        if (!BCrypt.checkpw(checkPassword, password))
+            throw new IllegalStateException("비밀번호가 일치하지 않습니다.");
     }
 }

--- a/src/main/java/umc/parasol/domain/member/dto/UpdatePwReq.java
+++ b/src/main/java/umc/parasol/domain/member/dto/UpdatePwReq.java
@@ -12,4 +12,6 @@ public class UpdatePwReq {
     @NotBlank(message = "새 비밀번호를 입력해야 합니다.")
     private String newPw;
 
+    @NotBlank(message = "refresh token을 입력해야 합니다.")
+    private String refreshToken;
 }

--- a/src/main/java/umc/parasol/domain/member/presentation/MemberController.java
+++ b/src/main/java/umc/parasol/domain/member/presentation/MemberController.java
@@ -1,4 +1,25 @@
 package umc.parasol.domain.member.presentation;
 
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.parasol.domain.member.application.MemberService;
+import umc.parasol.domain.member.dto.UpdatePwReq;
+import umc.parasol.global.config.security.token.CurrentUser;
+import umc.parasol.global.config.security.token.UserPrincipal;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
 public class MemberController {
+    private final MemberService memberService;
+    @PutMapping("/change-password")
+    public ResponseEntity<?> changePassword(@Valid @RequestBody UpdatePwReq updatePwReq,
+                                            @CurrentUser UserPrincipal user) {
+        return ResponseEntity.ok(memberService.updatePassword(updatePwReq, user));
+    }
 }


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 비밀번호 변경 로직 추가 
- [x] 비밀번호 변경 시 로그아웃 되도록 설정 

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- 비밀번호 변경 로직을 추가하였습니다. 변경값 저장은 `PasswordEncoder`의 `encode(String rawPassword)` 메서드를 활용하였습니다.
  - `RefreshTokenReq`를 전달해야 하기 때문에 `RefreshTokenReq`를 새로 생성할 수 있도록 생성자를 추가해두었습니다.
- 비밀번호 변경 뒤 로그아웃은 `AuthService`의 `signOut` 메서드를 활용하였습니다. 이때 `RefreshToken`이 필요하기 때문에, `UpdatePwReq`에 `refreshToken`을 두도록 하였습니다.

## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
