### PR TITLE
[FEAT]: 특정 매장 조회, 매장 검색 API 개발

### DIFF
--- a/src/main/java/umc/parasol/domain/image/domain/repository/ImageRepository.java
+++ b/src/main/java/umc/parasol/domain/image/domain/repository/ImageRepository.java
@@ -2,7 +2,12 @@ package umc.parasol.domain.image.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.parasol.domain.image.domain.Image;
+import umc.parasol.domain.shop.domain.Shop;
+
+import java.util.List;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
     Image findByUrl(String url);
+
+    List<Image> findAllByShop(Shop shop);
 }

--- a/src/main/java/umc/parasol/domain/image/dto/ImageRes.java
+++ b/src/main/java/umc/parasol/domain/image/dto/ImageRes.java
@@ -1,5 +1,6 @@
 package umc.parasol.domain.image.dto;
 
+import lombok.Builder;
 import lombok.Data;
 
 @Data
@@ -8,6 +9,7 @@ public class ImageRes {
     private Long id;
     private String url;
 
+    @Builder
     public ImageRes(Long id, String url) {
         this.id = id;
         this.url = url;

--- a/src/main/java/umc/parasol/domain/shop/application/ShopSearchService.java
+++ b/src/main/java/umc/parasol/domain/shop/application/ShopSearchService.java
@@ -1,0 +1,87 @@
+package umc.parasol.domain.shop.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.parasol.domain.member.domain.Member;
+import umc.parasol.domain.member.domain.repository.MemberRepository;
+import umc.parasol.domain.shop.domain.Shop;
+import umc.parasol.domain.shop.domain.repository.ShopRepository;
+import umc.parasol.domain.shop.dto.SearchShopReq;
+import umc.parasol.domain.shop.dto.SearchShopRes;
+import umc.parasol.global.DefaultAssert;
+import umc.parasol.global.config.security.token.UserPrincipal;
+
+import java.math.BigDecimal;
+import java.text.DecimalFormat;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ShopSearchService {
+
+    private final ShopRepository shopRepository;
+
+    private final MemberRepository memberRepository;
+
+    /**
+     * 매장 검색 결과 조회
+     * @param userPrincipal api 호출하는 사용자 객체
+     * @param searchShopReq 매장 검색 dto
+     */
+    public List<SearchShopRes> getSearchShop(UserPrincipal userPrincipal, SearchShopReq searchShopReq) {
+
+        Optional<Member> member = memberRepository.findById(userPrincipal.getId());
+        DefaultAssert.isTrue(member.isPresent(), "유저가 올바르지 않습니다.");
+
+        List<Shop> searchShopList = shopRepository.searchShopByKeyword(searchShopReq.getKeyword());
+
+        return searchShopList.stream().map(
+                shop -> SearchShopRes.builder()
+                        .id(shop.getId())
+                        .shopName(shop.getName())
+                        .roadNameAddress(shop.getRoadNameAddress())
+                        .distance(calculateDistance(searchShopReq.getUserLatitude(), searchShopReq.getUserLongitude(), shop.getLatitude(), shop.getLongitude()))
+                        .build()
+        ).toList();
+    }
+
+    /**
+     * 사용자의 위치와 매장 위치 사이의 거리를 계산해주는 메서드
+     * @param userLat 사용자의 위도
+     * @param userLon 사용자의 경도
+     * @param shopLat 매장의 위도
+     * @param shopLon 매장의 경도
+     * @return 계산된 거리 반환(m, km 구분)
+     */
+    public String calculateDistance(BigDecimal userLat, BigDecimal userLon, BigDecimal shopLat, BigDecimal shopLon) {
+        BigDecimal earthRadius = new BigDecimal("6371.0"); // 지구의 반지름 (단위: km)
+
+        double latDistance = Math.toRadians(shopLat.subtract(userLat).doubleValue());
+        double lonDistance = Math.toRadians(shopLon.subtract(userLon).doubleValue());
+
+        double a = Math.sin(latDistance / 2) * Math.sin(latDistance / 2)
+                + Math.cos(Math.toRadians(userLat.doubleValue())) * Math.cos(Math.toRadians(shopLat.doubleValue()))
+                * Math.sin(lonDistance / 2) * Math.sin(lonDistance / 2);
+
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        double distanceInKm = earthRadius.multiply(BigDecimal.valueOf(c)).doubleValue();
+
+        if (distanceInKm < 1.0) {
+            BigDecimal distanceInMeters = BigDecimal.valueOf(distanceInKm * 1000);
+            DecimalFormat df = new DecimalFormat("#");
+            String formattedDistance = df.format(distanceInMeters);
+
+            return formattedDistance+"m";
+        } else {
+            DecimalFormat df = new DecimalFormat("#.##");
+            String formattedDistance = df.format(distanceInKm);
+
+            return formattedDistance+"km";
+        }
+    }
+
+
+}

--- a/src/main/java/umc/parasol/domain/shop/application/ShopService.java
+++ b/src/main/java/umc/parasol/domain/shop/application/ShopService.java
@@ -1,20 +1,16 @@
 package umc.parasol.domain.shop.application;
 
-import lombok.Builder;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.parasol.domain.image.domain.Image;
 import umc.parasol.domain.image.domain.repository.ImageRepository;
 import umc.parasol.domain.image.dto.ImageRes;
 import umc.parasol.domain.member.domain.Member;
-import umc.parasol.domain.member.domain.Role;
 import umc.parasol.domain.member.domain.repository.MemberRepository;
 import umc.parasol.domain.shop.domain.Shop;
 import umc.parasol.domain.shop.domain.repository.ShopRepository;
 import umc.parasol.domain.shop.dto.*;
-import umc.parasol.global.DefaultAssert;
 import umc.parasol.global.config.security.token.UserPrincipal;
 
 import java.util.List;
@@ -37,62 +33,30 @@ public class ShopService {
      */
     public List<ShopListRes> getShopList(UserPrincipal userPrincipal) {
 
-        Optional<Member> member = memberRepository.findById(userPrincipal.getId());
-        DefaultAssert.isTrue(member.isPresent(), "유저가 올바르지 않습니다.");
-
+        findValidMember(userPrincipal.getId());
         List<Shop> shopList = shopRepository.findAll();
 
-        return shopList.stream().map(
-                shop -> ShopListRes.builder()
-                        .id(shop.getId())
-                        .shopName(shop.getName())
-                        .latitude(shop.getLatitude())
-                        .longitude(shop.getLongitude())
-                        .roadNameAddress(shop.getRoadNameAddress())
-                        .openTime(shop.getOpenTime())
-                        .closeTime(shop.getCloseTime())
-                        .availableUmbrella(shop.getAvailableUmbrella())
-                        .unavailableUmbrella(shop.getUnavailableUmbrella())
-                        .build()
-        ).toList();
+        return shopList.stream()
+                .map(this::createShopListRes)
+                .toList();
     }
 
     /**
      * 특정 매장 조회
-     *
      * @param userPrincipal api 호출하는 사용자 객체
      * @param shopId 조회할 매장의 ID
      */
     public ShopRes getShop(UserPrincipal userPrincipal, Long shopId) {
 
-        Optional<Member> member = memberRepository.findById(userPrincipal.getId());
-        DefaultAssert.isTrue(member.isPresent(), "유저가 올바르지 않습니다.");
+        findValidMember(userPrincipal.getId());
+        Shop shop = findValidShop(shopId);
 
-        Optional<Shop> shop = shopRepository.findById(shopId);
-        DefaultAssert.isTrue(shop.isPresent(), "매장이 올바르지 않습니다.");
-        Shop findShop = shop.get();
+        List<Image> imageList = imageRepository.findAllByShop(shop);
+        List<ImageRes> imageResList = imageList.stream()
+                .map(this::createImageRes)
+                .toList();
 
-        List<Image> imageList = imageRepository.findAllByShop(findShop);
-
-        List<ImageRes> imageResList = imageList.stream().map(
-                image -> ImageRes.builder()
-                        .id(image.getId())
-                        .url(image.getUrl())
-                        .build()
-        ).toList();
-
-        return ShopRes.builder()
-                .id(findShop.getId())
-                .shopName(findShop.getName())
-                .desc(findShop.getDescription())
-                .latitude(findShop.getLatitude())
-                .longitude(findShop.getLongitude())
-                .roadNameAddress(findShop.getRoadNameAddress())
-                .openTime(findShop.getOpenTime())
-                .closeTime(findShop.getCloseTime())
-                .availableUmbrella(findShop.getAvailableUmbrella())
-                .imageRes(imageResList)
-                .build();
+        return createShopRes(shop, imageResList);
     }
 
     /**
@@ -103,29 +67,67 @@ public class ShopService {
     @Transactional
     public ShopListRes updateUmbrellaCount(UserPrincipal userPrincipal, UpdateUmbrellaReq updateUmbrellaReq) {
 
-        Optional<Member> member = memberRepository.findById(userPrincipal.getId());
-        DefaultAssert.isTrue(member.isPresent(), "유저가 올바르지 않습니다.");
-        Member findMember = member.get();
+        Member member = findValidMember(userPrincipal.getId());
+        Shop shop = findValidShopForOwner(member);
+        shop.updateAvailableUmbrella(updateUmbrellaReq.getAvailableUmbrella());
 
-        // 사장님인지 체크
-        DefaultAssert.isTrue(findMember.getRole() == Role.OWNER, "사장님만 우산 개수를 수정할 수 있습니다.");
+        return createShopListRes(shop);
+    }
 
-        Optional<Shop> shop = Optional.ofNullable(findMember.getShop());
-        DefaultAssert.isTrue(shop.isPresent(), "연결된 매장이 없습니다.");
-        Shop findShop = shop.get();
+    // 유효한 사용자인지 체크하는 메서드
+    private Member findValidMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("유저가 올바르지 않습니다."));
+    }
 
-        findShop.updateAvailableUmbrella(updateUmbrellaReq.getAvailableUmbrella());
+    // 유효한 매장인지 체크하는 메서드
+    private Shop findValidShop(Long shopId) {
+        return shopRepository.findById(shopId)
+                .orElseThrow(() -> new IllegalArgumentException("매장이 올바르지 않습니다."));
+    }
 
+    // 사용자가 사장님인지 체크하는 메서드
+    private Shop findValidShopForOwner(Member member) {
+        return Optional.ofNullable(member.getShop())
+                .orElseThrow(() -> new IllegalArgumentException("연결된 매장이 없습니다."));
+    }
+
+    // ShopList 응답을 생성해주는 메서드
+    private ShopListRes createShopListRes(Shop shop) {
         return ShopListRes.builder()
-                .id(findShop.getId())
-                .shopName(findShop.getName())
-                .latitude(findShop.getLatitude())
-                .longitude(findShop.getLongitude())
-                .roadNameAddress(findShop.getRoadNameAddress())
-                .openTime(findShop.getOpenTime())
-                .closeTime(findShop.getCloseTime())
-                .availableUmbrella(findShop.getAvailableUmbrella())
-                .unavailableUmbrella(findShop.getUnavailableUmbrella())
+                .id(shop.getId())
+                .shopName(shop.getName())
+                .latitude(shop.getLatitude())
+                .longitude(shop.getLongitude())
+                .roadNameAddress(shop.getRoadNameAddress())
+                .openTime(shop.getOpenTime())
+                .closeTime(shop.getCloseTime())
+                .availableUmbrella(shop.getAvailableUmbrella())
+                .unavailableUmbrella(shop.getUnavailableUmbrella())
+                .build();
+    }
+
+    // Shop 응답을 생성해주는 메서드
+    private ShopRes createShopRes(Shop shop, List<ImageRes> imageResList) {
+        return ShopRes.builder()
+                .id(shop.getId())
+                .shopName(shop.getName())
+                .desc(shop.getDescription())
+                .latitude(shop.getLatitude())
+                .longitude(shop.getLongitude())
+                .roadNameAddress(shop.getRoadNameAddress())
+                .openTime(shop.getOpenTime())
+                .closeTime(shop.getCloseTime())
+                .availableUmbrella(shop.getAvailableUmbrella())
+                .image(imageResList)
+                .build();
+    }
+
+    // 이미지 응답을 생성해주는 메서드
+    private ImageRes createImageRes(Image image) {
+        return ImageRes.builder()
+                .id(image.getId())
+                .url(image.getUrl())
                 .build();
     }
 }

--- a/src/main/java/umc/parasol/domain/shop/application/ShopService.java
+++ b/src/main/java/umc/parasol/domain/shop/application/ShopService.java
@@ -13,9 +13,7 @@ import umc.parasol.domain.member.domain.Role;
 import umc.parasol.domain.member.domain.repository.MemberRepository;
 import umc.parasol.domain.shop.domain.Shop;
 import umc.parasol.domain.shop.domain.repository.ShopRepository;
-import umc.parasol.domain.shop.dto.ShopListRes;
-import umc.parasol.domain.shop.dto.ShopRes;
-import umc.parasol.domain.shop.dto.UpdateUmbrellaReq;
+import umc.parasol.domain.shop.dto.*;
 import umc.parasol.global.DefaultAssert;
 import umc.parasol.global.config.security.token.UserPrincipal;
 

--- a/src/main/java/umc/parasol/domain/shop/domain/repository/ShopRepository.java
+++ b/src/main/java/umc/parasol/domain/shop/domain/repository/ShopRepository.java
@@ -1,12 +1,17 @@
 package umc.parasol.domain.shop.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import umc.parasol.domain.image.domain.Image;
 import umc.parasol.domain.shop.domain.Shop;
 
 import java.util.List;
 
 @Repository
 public interface ShopRepository extends JpaRepository<Shop, Long> {
+
+    @Query("SELECT s FROM Shop s WHERE s.name LIKE %:searchKeyword% OR s.roadNameAddress LIKE %:searchKeyword%")
+    List<Shop> searchShopByKeyword(@Param("searchKeyword") String searchKeyword);
+
 }

--- a/src/main/java/umc/parasol/domain/shop/domain/repository/ShopRepository.java
+++ b/src/main/java/umc/parasol/domain/shop/domain/repository/ShopRepository.java
@@ -2,7 +2,10 @@ package umc.parasol.domain.shop.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import umc.parasol.domain.image.domain.Image;
 import umc.parasol.domain.shop.domain.Shop;
+
+import java.util.List;
 
 @Repository
 public interface ShopRepository extends JpaRepository<Shop, Long> {

--- a/src/main/java/umc/parasol/domain/shop/dto/SearchShopReq.java
+++ b/src/main/java/umc/parasol/domain/shop/dto/SearchShopReq.java
@@ -1,0 +1,20 @@
+package umc.parasol.domain.shop.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+public class SearchShopReq {
+
+    @NotBlank(message = "검색어를 입력해야 합니다.")
+    private String keyword;
+
+    @NotNull(message = "사용자의 위도를 입력해야 합니다.")
+    private BigDecimal userLatitude;
+
+    @NotNull(message = "사용자의 경도를 입력해야 합니다.")
+    private BigDecimal userLongitude;
+}

--- a/src/main/java/umc/parasol/domain/shop/dto/SearchShopRes.java
+++ b/src/main/java/umc/parasol/domain/shop/dto/SearchShopRes.java
@@ -1,0 +1,19 @@
+package umc.parasol.domain.shop.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+
+@Data
+@Builder
+public class SearchShopRes {
+
+    private Long id;
+
+    private String shopName;
+
+    private String roadNameAddress;
+
+    private String distance;
+
+}

--- a/src/main/java/umc/parasol/domain/shop/dto/ShopRes.java
+++ b/src/main/java/umc/parasol/domain/shop/dto/ShopRes.java
@@ -1,0 +1,35 @@
+package umc.parasol.domain.shop.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import umc.parasol.domain.image.dto.ImageRes;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Data
+@Builder
+public class ShopRes {
+
+    private Long id;
+
+    private String shopName;
+
+    private String desc;
+
+    private BigDecimal latitude;
+
+    private BigDecimal longitude;
+
+    private String roadNameAddress;
+
+    private String openTime;
+
+    private String closeTime;
+
+    private int availableUmbrella;
+
+    private List<ImageRes> imageRes;
+
+
+}

--- a/src/main/java/umc/parasol/domain/shop/dto/ShopRes.java
+++ b/src/main/java/umc/parasol/domain/shop/dto/ShopRes.java
@@ -29,7 +29,7 @@ public class ShopRes {
 
     private int availableUmbrella;
 
-    private List<ImageRes> imageRes;
+    private List<ImageRes> image;
 
 
 }

--- a/src/main/java/umc/parasol/domain/shop/presentation/ShopController.java
+++ b/src/main/java/umc/parasol/domain/shop/presentation/ShopController.java
@@ -6,10 +6,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import umc.parasol.domain.image.application.ImageService;
+import umc.parasol.domain.shop.application.ShopSearchService;
 import umc.parasol.domain.shop.application.ShopService;
-import umc.parasol.domain.shop.dto.ShopListRes;
-import umc.parasol.domain.shop.dto.ShopRes;
-import umc.parasol.domain.shop.dto.UpdateUmbrellaReq;
+import umc.parasol.domain.shop.dto.*;
 import umc.parasol.global.config.security.token.CurrentUser;
 import umc.parasol.global.config.security.token.UserPrincipal;
 import umc.parasol.global.payload.ApiResponse;
@@ -22,6 +21,8 @@ import java.util.List;
 public class ShopController {
 
     private final ShopService shopService;
+
+    private final ShopSearchService shopSearchService;
 
     private final ImageService imageService;
 
@@ -51,6 +52,22 @@ public class ShopController {
         ApiResponse apiResponse = ApiResponse.builder()
                 .check(true)
                 .information(shopRes)
+                .build();
+
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    // 매장 검색 결과 조회
+    @GetMapping("/search")
+    public ResponseEntity<?> searchShop(
+            @CurrentUser UserPrincipal userPrincipal,
+            @RequestBody SearchShopReq searchShopReq) {
+
+        List<SearchShopRes> searchShopRes = shopSearchService.getSearchShop(userPrincipal, searchShopReq);
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information(searchShopRes)
                 .build();
 
         return ResponseEntity.ok(apiResponse);

--- a/src/main/java/umc/parasol/domain/shop/presentation/ShopController.java
+++ b/src/main/java/umc/parasol/domain/shop/presentation/ShopController.java
@@ -8,6 +8,7 @@ import org.springframework.web.multipart.MultipartFile;
 import umc.parasol.domain.image.application.ImageService;
 import umc.parasol.domain.shop.application.ShopService;
 import umc.parasol.domain.shop.dto.ShopListRes;
+import umc.parasol.domain.shop.dto.ShopRes;
 import umc.parasol.domain.shop.dto.UpdateUmbrellaReq;
 import umc.parasol.global.config.security.token.CurrentUser;
 import umc.parasol.global.config.security.token.UserPrincipal;
@@ -21,9 +22,10 @@ import java.util.List;
 public class ShopController {
 
     private final ShopService shopService;
+
     private final ImageService imageService;
 
-    // 매장 조회
+    // 매장 리스트 조회
     @GetMapping
     public ResponseEntity<?> getShopList(
             @CurrentUser UserPrincipal userPrincipal) {
@@ -33,6 +35,22 @@ public class ShopController {
         ApiResponse apiResponse = ApiResponse.builder()
                 .check(true)
                 .information(shopListRes)
+                .build();
+
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    // 특정 매장 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getShop(
+            @CurrentUser UserPrincipal userPrincipal,
+            @PathVariable(value = "id") Long shopId) {
+
+        ShopRes shopRes = shopService.getShop(userPrincipal, shopId);
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information(shopRes)
                 .build();
 
         return ResponseEntity.ok(apiResponse);


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 특정 매장 조회 API 개발 
- [x] 매장 검색 API 개발 

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- 매장 ID를 입력하고 해당 ID에 해당하는 매장의 상세 정보를 조회하는 API 입니다. 등록된 Image를 불러옵니다.
- 매장 검색 API에서 현재는 검색어에 매장 이름 또는 도로명 주소가 포함된다면 조회가 되게 해놨는데 사용자 편의성을 높이려면 지번주소(광역시도-시군구-읍면동-숫자-(건물명-호수))까지 추가하면 좋을 것 같습니다.
- 매장 검색 관련된 서비스 로직은 `ShopSearchService`로 분리했습니다.


## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
- 
