### PR TITLE
[FEAT] Umbrella 엔티티 복구 및 우산 초기 등록, 우산 구입 로직 작성

### DIFF
--- a/src/main/java/umc/parasol/domain/auth/application/AuthSignService.java
+++ b/src/main/java/umc/parasol/domain/auth/application/AuthSignService.java
@@ -68,8 +68,6 @@ public class AuthSignService {
                 .latitude(signUpOwnerReq.getLatitude())
                 .longitude(signUpOwnerReq.getLongitude())
                 .roadNameAddress(signUpOwnerReq.getRoadNameAddress())
-                .availableUmbrella(0)
-                .unavailableUmbrella(0)
                 .build();
 
         shopRepository.save(newShop);

--- a/src/main/java/umc/parasol/domain/shop/application/ShopService.java
+++ b/src/main/java/umc/parasol/domain/shop/application/ShopService.java
@@ -59,21 +59,6 @@ public class ShopService {
         return createShopRes(shop, imageResList);
     }
 
-    /**
-     * 대여 가능한 우산 개수 업데이트
-     * @param userPrincipal api 호출하는 사용자 객체
-     * @param updateUmbrellaReq 우산 개수 업데이트 dto
-     */
-    @Transactional
-    public ShopListRes updateUmbrellaCount(UserPrincipal userPrincipal, UpdateUmbrellaReq updateUmbrellaReq) {
-
-        Member member = findValidMember(userPrincipal.getId());
-        Shop shop = findValidShopForOwner(member);
-        shop.updateAvailableUmbrella(updateUmbrellaReq.getAvailableUmbrella());
-
-        return createShopListRes(shop);
-    }
-
     // 유효한 사용자인지 체크하는 메서드
     private Member findValidMember(Long memberId) {
         return memberRepository.findById(memberId)
@@ -102,8 +87,6 @@ public class ShopService {
                 .roadNameAddress(shop.getRoadNameAddress())
                 .openTime(shop.getOpenTime())
                 .closeTime(shop.getCloseTime())
-                .availableUmbrella(shop.getAvailableUmbrella())
-                .unavailableUmbrella(shop.getUnavailableUmbrella())
                 .build();
     }
 
@@ -118,7 +101,6 @@ public class ShopService {
                 .roadNameAddress(shop.getRoadNameAddress())
                 .openTime(shop.getOpenTime())
                 .closeTime(shop.getCloseTime())
-                .availableUmbrella(shop.getAvailableUmbrella())
                 .image(imageResList)
                 .build();
     }

--- a/src/main/java/umc/parasol/domain/shop/domain/Shop.java
+++ b/src/main/java/umc/parasol/domain/shop/domain/Shop.java
@@ -42,19 +42,4 @@ public class Shop extends BaseEntity {
     private String openTime;
 
     private String closeTime;
-
-    // 매장의 대여 가능한 우산 개수
-    private int availableUmbrella;
-
-    // 매장의 대여 중인 우산 개수 (대여 불가)
-    private int unavailableUmbrella;
-
-    // update 메서드
-    public void updateAvailableUmbrella(int count) {
-        this.availableUmbrella = count;
-    }
-
-    public void updateUnavailableUmbrella(int count) {
-        this.unavailableUmbrella = count;
-    }
 }

--- a/src/main/java/umc/parasol/domain/shop/presentation/ShopController.java
+++ b/src/main/java/umc/parasol/domain/shop/presentation/ShopController.java
@@ -73,23 +73,6 @@ public class ShopController {
         return ResponseEntity.ok(apiResponse);
     }
 
-    // 대여 가능 우산 개수 업데이트
-    @PutMapping("/umbrella")
-    public ResponseEntity<?> updateUmbrella(
-            @CurrentUser UserPrincipal userPrincipal,
-            @RequestBody UpdateUmbrellaReq updateUmbrellaReq) {
-
-        ShopListRes shopListRes = shopService.updateUmbrellaCount(userPrincipal, updateUmbrellaReq);
-
-
-        ApiResponse apiResponse = ApiResponse.builder()
-                .check(true)
-                .information(shopListRes)
-                .build();
-
-        return ResponseEntity.ok(apiResponse);
-    }
-
     // 매장 사진 업로드
     @PostMapping(value = "/{id}/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<?> imageUpload(@RequestParam(value = "image")

--- a/src/main/java/umc/parasol/domain/umbrella/application/UmbrellaService.java
+++ b/src/main/java/umc/parasol/domain/umbrella/application/UmbrellaService.java
@@ -6,7 +6,6 @@ import org.springframework.transaction.annotation.Transactional;
 import umc.parasol.domain.member.domain.Member;
 import umc.parasol.domain.member.domain.repository.MemberRepository;
 import umc.parasol.domain.shop.domain.Shop;
-import umc.parasol.domain.umbrella.domain.Level;
 import umc.parasol.domain.umbrella.domain.Umbrella;
 import umc.parasol.domain.umbrella.domain.repository.UmbrellaRepository;
 import umc.parasol.global.config.security.token.UserPrincipal;
@@ -83,7 +82,7 @@ public class UmbrellaService {
     // 매장에 등록된 우산 중 남은 우산이 비어있는지
     private boolean isNoMoreFree(Shop shop) {
         List<Umbrella> umbrellaList = getShopUmbrellaList(shop).stream()
-                .filter(umbrella -> umbrella.getLevel() == Level.FREE).toList();
+                .filter(Umbrella::isAvailable).toList();
         return umbrellaList.isEmpty();
     }
 
@@ -101,7 +100,7 @@ public class UmbrellaService {
     // Shop이 가지고 있는 FREE 상태의 우산 목록 중 0번째 값을 활용
     private Umbrella getAnyFreeUmbrella(Shop shop) {
         return getShopUmbrellaList(shop).stream()
-                .filter(umbrella -> umbrella.getLevel() == Level.FREE)
+                .filter(Umbrella::isAvailable)
                 .toList()
                 .get(0);
     }

--- a/src/main/java/umc/parasol/domain/umbrella/application/UmbrellaService.java
+++ b/src/main/java/umc/parasol/domain/umbrella/application/UmbrellaService.java
@@ -1,0 +1,108 @@
+package umc.parasol.domain.umbrella.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.parasol.domain.member.domain.Member;
+import umc.parasol.domain.member.domain.repository.MemberRepository;
+import umc.parasol.domain.shop.domain.Shop;
+import umc.parasol.domain.umbrella.domain.Level;
+import umc.parasol.domain.umbrella.domain.Umbrella;
+import umc.parasol.domain.umbrella.domain.repository.UmbrellaRepository;
+import umc.parasol.global.config.security.token.UserPrincipal;
+import umc.parasol.global.payload.ApiResponse;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UmbrellaService {
+
+    private final UmbrellaRepository umbrellaRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    // 초기 세팅 (처음에 Shop 등록했을 시 몇 개 우산 가지고 있는지 설정)
+    public ApiResponse init(UserPrincipal user, int count) {
+        if (count > Umbrella.MAX || count <= 0)
+            throw new IllegalStateException("우산 갯수가 올바르지 않습니다.");
+
+        Member owner = getShopOwner(user);
+        Shop targetShop = owner.getShop();
+        IntStream.range(0, count)
+                .mapToObj(i -> Umbrella.createUmbrella(targetShop))
+                .forEach(umbrellaRepository::save);
+
+        return new ApiResponse(true, "등록 완료");
+    }
+
+    /*
+    @Transactional
+    // 손님에게 우산을 빌려주기 (남은 우산이 있어야만 가능)
+    // History와도 관련됨 - HistoryService에서 처리해야 할 수도 있음
+    public void borrow(UserPrincipal user) {
+        Member owner = getShopOwner(user);
+        Shop targetShop = owner.getShop();
+        if (isNoMoreFree(targetShop)) {
+            throw new IllegalStateException("가능한 우산이 없습니다.");
+        }
+        Umbrella umbrella = getAnyFreeUmbrella(targetShop);
+        umbrella.updateLevel(Level.USE);
+    }
+    */
+
+    @Transactional
+    // 손님에게 중고 우산을 구매함
+    public ApiResponse buyUmbrella(UserPrincipal user) {
+        Member owner = getShopOwner(user);
+        Shop targetShop = owner.getShop();
+        if (isFull(targetShop))
+            throw new IllegalStateException("더 이상 우산을 채울 수 없습니다.");
+        Umbrella newUmbrella = Umbrella.createUmbrella(targetShop);
+        umbrellaRepository.save(newUmbrella);
+
+        return new ApiResponse(true, "구입 완료");
+    }
+
+    /*
+    // 빌린 손님이 반납함 - 원래 매장에 반납하는지, 새 매장에 반납하는지 구분해야 함
+    // History와도 관련됨 - HistoryService에서 처리해야 할 수도 있음
+    public void getBack() {
+
+    }
+    */
+
+   // 한 매장 당 가질 수 있는 우산 갯수가 최대치를 초과했는지
+    private boolean isFull(Shop shop) {
+        List<Umbrella> umbrellaList = getShopUmbrellaList(shop);
+        return umbrellaList.size() == Umbrella.MAX;
+    }
+
+    // 매장에 등록된 우산 중 남은 우산이 비어있는지
+    private boolean isNoMoreFree(Shop shop) {
+        List<Umbrella> umbrellaList = getShopUmbrellaList(shop).stream()
+                .filter(umbrella -> umbrella.getLevel() == Level.FREE).toList();
+        return umbrellaList.isEmpty();
+    }
+
+    // Shop에 등록된 우산 갯수 전부 가져오기 (FREE, USE 모두)
+    private List<Umbrella> getShopUmbrellaList(Shop shop) {
+        return umbrellaRepository.findAllByShop(shop);
+    }
+
+    // 현재 로그인 한 멤버를 가져오는 작업
+    private Member getShopOwner(UserPrincipal user) {
+        return memberRepository.findById(user.getId())
+                .orElseThrow(() -> new IllegalStateException("해당 member가 없습니다."));
+    }
+
+    // Shop이 가지고 있는 FREE 상태의 우산 목록 중 0번째 값을 활용
+    private Umbrella getAnyFreeUmbrella(Shop shop) {
+        return getShopUmbrellaList(shop).stream()
+                .filter(umbrella -> umbrella.getLevel() == Level.FREE)
+                .toList()
+                .get(0);
+    }
+}

--- a/src/main/java/umc/parasol/domain/umbrella/domain/Level.java
+++ b/src/main/java/umc/parasol/domain/umbrella/domain/Level.java
@@ -1,0 +1,5 @@
+package umc.parasol.domain.umbrella.domain;
+
+public enum Level {
+    FREE, USE
+}

--- a/src/main/java/umc/parasol/domain/umbrella/domain/Level.java
+++ b/src/main/java/umc/parasol/domain/umbrella/domain/Level.java
@@ -1,5 +1,0 @@
-package umc.parasol.domain.umbrella.domain;
-
-public enum Level {
-    FREE, USE
-}

--- a/src/main/java/umc/parasol/domain/umbrella/domain/Umbrella.java
+++ b/src/main/java/umc/parasol/domain/umbrella/domain/Umbrella.java
@@ -23,15 +23,14 @@ public class Umbrella extends BaseEntity {
     @JoinColumn(name = "shop_id")
     private Shop shop;
 
-    @Enumerated(value = EnumType.STRING)
-    private Level level;
+    private boolean available;
 
     public static final int MAX = 10;
 
     public static Umbrella createUmbrella(Shop shop) {
         Umbrella newUmbrella = new Umbrella();
         newUmbrella.updateShop(shop);
-        newUmbrella.updateLevel(Level.FREE);
+        newUmbrella.updateAvailable(true);
         return newUmbrella;
     }
 
@@ -39,7 +38,7 @@ public class Umbrella extends BaseEntity {
         this.shop = shop;
     }
 
-    public void updateLevel(Level level) {
-        this.level = level;
+    public void updateAvailable(boolean available) {
+        this.available = available;
     }
 }

--- a/src/main/java/umc/parasol/domain/umbrella/domain/Umbrella.java
+++ b/src/main/java/umc/parasol/domain/umbrella/domain/Umbrella.java
@@ -1,0 +1,45 @@
+package umc.parasol.domain.umbrella.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Where;
+import umc.parasol.domain.common.BaseEntity;
+import umc.parasol.domain.shop.domain.Shop;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Where(clause = "status = 'ACTIVE'")
+public class Umbrella extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "umbrella_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shop_id")
+    private Shop shop;
+
+    @Enumerated(value = EnumType.STRING)
+    private Level level;
+
+    public static final int MAX = 10;
+
+    public static Umbrella createUmbrella(Shop shop) {
+        Umbrella newUmbrella = new Umbrella();
+        newUmbrella.updateShop(shop);
+        newUmbrella.updateLevel(Level.FREE);
+        return newUmbrella;
+    }
+
+    public void updateShop(Shop shop) {
+        this.shop = shop;
+    }
+
+    public void updateLevel(Level level) {
+        this.level = level;
+    }
+}

--- a/src/main/java/umc/parasol/domain/umbrella/domain/repository/UmbrellaRepository.java
+++ b/src/main/java/umc/parasol/domain/umbrella/domain/repository/UmbrellaRepository.java
@@ -1,0 +1,11 @@
+package umc.parasol.domain.umbrella.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.parasol.domain.shop.domain.Shop;
+import umc.parasol.domain.umbrella.domain.Umbrella;
+
+import java.util.List;
+
+public interface UmbrellaRepository extends JpaRepository<Umbrella, Long> {
+    List<Umbrella> findAllByShop(Shop shop);
+}

--- a/src/main/java/umc/parasol/domain/umbrella/dto/UmbrellaAddReq.java
+++ b/src/main/java/umc/parasol/domain/umbrella/dto/UmbrellaAddReq.java
@@ -1,0 +1,10 @@
+package umc.parasol.domain.umbrella.dto;
+
+import lombok.Data;
+import lombok.Getter;
+
+@Data
+@Getter
+public class UmbrellaAddReq {
+    private int count;
+}

--- a/src/main/java/umc/parasol/domain/umbrella/presentation/UmbrellaController.java
+++ b/src/main/java/umc/parasol/domain/umbrella/presentation/UmbrellaController.java
@@ -1,0 +1,40 @@
+package umc.parasol.domain.umbrella.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.parasol.domain.umbrella.application.UmbrellaService;
+import umc.parasol.domain.umbrella.dto.UmbrellaAddReq;
+import umc.parasol.global.config.security.token.CurrentUser;
+import umc.parasol.global.config.security.token.UserPrincipal;
+
+@RestController
+@RequestMapping("/api/umbrella")
+@RequiredArgsConstructor
+public class UmbrellaController {
+
+    private final UmbrellaService umbrellaService;
+
+    @PostMapping("/init")
+    // 매장에 우산 초기 등록
+    public ResponseEntity<?> umbrellaSetting(@CurrentUser UserPrincipal user, @RequestBody UmbrellaAddReq req) {
+        try {
+            return ResponseEntity.ok(umbrellaService.init(user, req.getCount()));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+    @PostMapping("/buy")
+    // 손님으로부터 우산 구입
+    public ResponseEntity<?> buyUmbrella(@CurrentUser UserPrincipal user) {
+        try {
+            return ResponseEntity.ok(umbrellaService.buyUmbrella(user));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] Umbrella 엔티티 복구 
- [x] 우산 초기 등록 메서드 추가
- [x] 손님으로부터 우산 구입 메서드 추가  
- [x] Shop이 가지고 있던 `availableUmbrella`, `unavailableUmbrella` 삭제

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- 회의 내용에 따라 `Umbrella` 엔티티를 복구했습니다. `Shop` : `Umbrella` = 1 : N 관계로 설정했습니다.
- 초기 우산 갯수 설정, 손님으로부터 우산 구입 메서드는 `ShopController`보다 `UmbrellaController`에서 진행하는 게 적합할 것 같아 `UmbrellaController`에서 진행하였습니다.
- `Umbrella` 엔티티를 복구함에 따라, Shop이 가지고 있던 `availableUmbrella`, `unavailableUmbrella`를 삭제했습니다.
- 한 매장 당 가질 수 있는 최대 우산 사이즈는 10개로 해두었습니다.
- 우산 생성 코드는 엔티티에 두었습니다.
- 우산 반납, 우산 대여 등은 `History`와도 연결되어야 할 것 같아 일단 주석 처리 해두었습니다.
- 응답 형식을 일단 간단하게 String 형식으로 진행하였습니다. 향후 수정하겠습니다.
- 우산의 상태는 Level Enum 타입으로 두었습니다. FREE, USE로 구분됩니다. -> boolean available로 변경하였습니다.

## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
