### PR TITLE
[FEAT] History 엔티티 기능 개발

### DIFF
--- a/src/main/java/umc/parasol/domain/history/application/HistoryService.java
+++ b/src/main/java/umc/parasol/domain/history/application/HistoryService.java
@@ -1,4 +1,127 @@
 package umc.parasol.domain.history.application;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.parasol.domain.history.domain.History;
+import umc.parasol.domain.history.domain.Process;
+import umc.parasol.domain.history.domain.dto.HistoryRes;
+import umc.parasol.domain.history.domain.repository.HistoryRepository;
+import umc.parasol.domain.member.domain.Member;
+import umc.parasol.domain.member.domain.repository.MemberRepository;
+import umc.parasol.domain.shop.domain.Shop;
+import umc.parasol.domain.shop.domain.repository.ShopRepository;
+import umc.parasol.domain.umbrella.application.UmbrellaService;
+import umc.parasol.domain.umbrella.domain.Umbrella;
+import umc.parasol.global.config.security.token.CurrentUser;
+import umc.parasol.global.config.security.token.UserPrincipal;
+import umc.parasol.global.payload.ApiResponse;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class HistoryService {
+    private final HistoryRepository historyRepository;
+    private final MemberRepository memberRepository;
+    private final ShopRepository shopRepository;
+    private final UmbrellaService umbrellaService;
+
+    // 손님이 우산 결제 진행
+    @Transactional
+    public ApiResponse createHistory(@CurrentUser UserPrincipal user, Long shopId) {
+        Shop targetShop = findShopById(shopId);
+        Member member = findMemberById(user.getId());
+        History history = createHistory(targetShop, member);
+        historyRepository.save(history);
+
+        HistoryRes record = makeHistoryRes(member, history, null);
+        return new ApiResponse(true, record);
+    }
+
+    // 손님이 우산 반납 진행
+    @Transactional
+    public ApiResponse giveBack(@CurrentUser UserPrincipal user, Long shopId) {
+        Member member = findMemberById(user.getId());
+
+        List<History> remainHistoryList = historyRepository.findAllByMember(member)
+                .stream()
+                .filter(history -> history.getProcess() != Process.CLEAR).toList();
+
+        if (remainHistoryList.isEmpty())
+            throw new IllegalStateException("처리되지 않은 우산 내역이 없습니다.");
+
+        History targetHistory = remainHistoryList.get(0);
+        Umbrella targetUmbrella = targetHistory.getUmbrella();
+        targetHistory.updateProcess(Process.CLEAR); // History CLEAR 상태로 변경
+
+        Shop originShop = targetHistory.getFromShop();
+        Shop targetShop = findShopById(shopId);
+
+        targetUmbrella.updateAvailable(true);
+        targetHistory.updateEndShop(originShop);
+        if (originShop != targetShop) { // 빌렸던 Shop과 다르다면
+            if (umbrellaService.isFull(targetShop))
+                throw new IllegalStateException("더 이상 우산을 채울 수 없습니다.");
+
+            targetUmbrella.updateShop(targetShop);
+            targetHistory.updateEndShop(targetShop);
+        }
+        targetHistory.updateClearedAt(LocalDateTime.now());
+        HistoryRes record = makeHistoryRes(member, targetHistory, targetShop);
+        return new ApiResponse(true, record);
+    }
+
+    // 손님의 대여 기록들 조회
+    public ApiResponse historyList(@CurrentUser UserPrincipal user) {
+        Member member = findMemberById(user.getId());
+        List<History> historyList = historyRepository.findAllByMember(member);
+        List<HistoryRes> historyResList = new ArrayList<>();
+        for (History history : historyList) {
+            historyResList.add(makeHistoryRes(member, history, null));
+        }
+
+        return new ApiResponse(true, historyResList);
+    }
+
+    private Shop findShopById(Long shopId) {
+        return shopRepository.findById(shopId).orElseThrow(
+                () -> new IllegalStateException("해당 shop이 없습니다.")
+        );
+    }
+
+    private Member findMemberById(Long memerId) {
+        return memberRepository.findById(memerId).orElseThrow(
+                () -> new IllegalStateException("해당 member가 없습니다.")
+        );
+    }
+
+    private HistoryRes makeHistoryRes(Member member, History history, Shop endShop) {
+        return HistoryRes.builder()
+                .member(member.getNickname())
+                .fromShop(history.getFromShop().getName())
+                .endShop((endShop == null) ?
+                        (history.getEndShop() == null
+                                ? null
+                                : history.getEndShop().getName())
+                        : endShop.getName())
+                .createdAt(history.getCreatedAt())
+                .clearedAt(history.getClearedAt())
+                .process(history.getProcess())
+                .build();
+    }
+
+    private History createHistory(Shop targetShop, Member member) {
+        return History.builder()
+                .cost(0L)
+                .process(Process.USE)
+                .fromShop(targetShop)
+                .endShop(null)
+                .member(member)
+                .umbrella(umbrellaService.getAnyFreeUmbrella(targetShop))
+                .build();
+    }
 }

--- a/src/main/java/umc/parasol/domain/history/application/HistoryService.java
+++ b/src/main/java/umc/parasol/domain/history/application/HistoryService.java
@@ -62,7 +62,11 @@ public class HistoryService {
         Shop targetShop = findShopById(shopId);
 
         targetUmbrella.updateAvailable(true);
-        targetHistory.updateEndShop(originShop);
+
+        // 빌렸던 지점에 반납 가능하다면 일단 임시로 EndShop으로 등록
+        if (!umbrellaService.isFull(originShop))
+            targetHistory.updateEndShop(originShop);
+
         if (originShop != targetShop) { // 빌렸던 Shop과 다르다면
             if (umbrellaService.isFull(targetShop))
                 throw new IllegalStateException("더 이상 우산을 채울 수 없습니다.");

--- a/src/main/java/umc/parasol/domain/history/domain/History.java
+++ b/src/main/java/umc/parasol/domain/history/domain/History.java
@@ -10,6 +10,9 @@ import org.hibernate.annotations.Where;
 import umc.parasol.domain.common.BaseEntity;
 import umc.parasol.domain.member.domain.Member;
 import umc.parasol.domain.shop.domain.Shop;
+import umc.parasol.domain.umbrella.domain.Umbrella;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Builder
@@ -30,8 +33,17 @@ public class History extends BaseEntity {
     
     @ManyToOne(fetch = FetchType.LAZY)
     @NotNull(message = "관련 상점이 설정되어 있어야 합니다.")
-    @JoinColumn(name = "shop_id")
-    private Shop shop;
+    @JoinColumn(name = "from_shop_id")
+    private Shop fromShop;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "end_shop_id")
+    private Shop endShop;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @NotNull(message = "관련 우산이 설정되어 있어야 합니다.")
+    @JoinColumn(name = "umbrella_id")
+    private Umbrella umbrella;
 
     @NotNull(message = "가격이 설정되어 있어야 합니다.")
     private Long cost;
@@ -39,4 +51,18 @@ public class History extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @NotNull(message = "절차가 설정되어 있어야 합니다.")
     private Process process;
+
+    private LocalDateTime clearedAt;
+
+    public void updateProcess(Process process) {
+        this.process = process;
+    }
+
+    public void updateEndShop(Shop shop) {
+        this.endShop = shop;
+    }
+
+    public void updateClearedAt(LocalDateTime clearedAt) {
+        this.clearedAt = clearedAt;
+    }
 }

--- a/src/main/java/umc/parasol/domain/history/domain/dto/HistoryRes.java
+++ b/src/main/java/umc/parasol/domain/history/domain/dto/HistoryRes.java
@@ -1,0 +1,33 @@
+package umc.parasol.domain.history.domain.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.parasol.domain.history.domain.Process;
+
+import java.time.LocalDateTime;
+
+@Data
+@Getter
+@NoArgsConstructor
+public class HistoryRes {
+    private String member; // member 이름
+    private String fromShop; // 빌린 매장 이름
+    private String endShop; // 반환한 매장 이름
+
+    private LocalDateTime createdAt; // 대여 시각
+    private LocalDateTime clearedAt; // 종료 시각
+    private Process process; // 내역 단계
+
+    @Builder
+    public HistoryRes(String member, String fromShop, String endShop, LocalDateTime createdAt,
+                      LocalDateTime clearedAt, Process process) {
+        this.member = member;
+        this.fromShop = fromShop;
+        this.endShop = endShop;
+        this.createdAt = createdAt;
+        this.clearedAt = clearedAt;
+        this.process = process;
+    }
+}

--- a/src/main/java/umc/parasol/domain/history/domain/repository/HistoryRepository.java
+++ b/src/main/java/umc/parasol/domain/history/domain/repository/HistoryRepository.java
@@ -1,4 +1,11 @@
 package umc.parasol.domain.history.domain.repository;
 
-public interface HistoryRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.parasol.domain.history.domain.History;
+import umc.parasol.domain.member.domain.Member;
+
+import java.util.List;
+
+public interface HistoryRepository extends JpaRepository<History, Long> {
+    List<History> findAllByMember(Member member);
 }

--- a/src/main/java/umc/parasol/domain/history/presentation/HIstoryController.java
+++ b/src/main/java/umc/parasol/domain/history/presentation/HIstoryController.java
@@ -1,4 +1,0 @@
-package umc.parasol.domain.history.presentation;
-
-public class HIstoryController {
-}

--- a/src/main/java/umc/parasol/domain/history/presentation/HistoryController.java
+++ b/src/main/java/umc/parasol/domain/history/presentation/HistoryController.java
@@ -1,0 +1,45 @@
+package umc.parasol.domain.history.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import umc.parasol.domain.history.application.HistoryService;
+import umc.parasol.global.config.security.token.CurrentUser;
+import umc.parasol.global.config.security.token.UserPrincipal;
+
+@RestController
+@RequestMapping("/api/history")
+@RequiredArgsConstructor
+public class HistoryController {
+    private final HistoryService historyService;
+
+    // 손님이 우산 대여
+    @PostMapping("/add/{id}")
+    public ResponseEntity<?> addHistory(@CurrentUser UserPrincipal user, @PathVariable Long id) {
+        try {
+            return ResponseEntity.ok(historyService.createHistory(user, id));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+    // 손님의 우산 반납
+    @PostMapping("/back/{id}")
+    public ResponseEntity<?> backUmbrella(@CurrentUser UserPrincipal user, @PathVariable Long id) {
+        try {
+            return ResponseEntity.ok(historyService.giveBack(user, id));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+    // 손님의 대여 목록
+    @GetMapping("/mine")
+    public ResponseEntity<?> histories(@CurrentUser UserPrincipal user) {
+        try {
+            return ResponseEntity.ok(historyService.historyList(user));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/umc/parasol/domain/umbrella/application/UmbrellaService.java
+++ b/src/main/java/umc/parasol/domain/umbrella/application/UmbrellaService.java
@@ -74,7 +74,7 @@ public class UmbrellaService {
     */
 
    // 한 매장 당 가질 수 있는 우산 갯수가 최대치를 초과했는지
-    private boolean isFull(Shop shop) {
+    public boolean isFull(Shop shop) {
         List<Umbrella> umbrellaList = getShopUmbrellaList(shop);
         return umbrellaList.size() == Umbrella.MAX;
     }
@@ -97,11 +97,19 @@ public class UmbrellaService {
                 .orElseThrow(() -> new IllegalStateException("해당 member가 없습니다."));
     }
 
+    @Transactional
     // Shop이 가지고 있는 FREE 상태의 우산 목록 중 0번째 값을 활용
-    private Umbrella getAnyFreeUmbrella(Shop shop) {
-        return getShopUmbrellaList(shop).stream()
+    public Umbrella getAnyFreeUmbrella(Shop shop) {
+        List<Umbrella> umbrellaList = getShopUmbrellaList(shop).stream()
                 .filter(Umbrella::isAvailable)
-                .toList()
-                .get(0);
+                .toList();
+
+        if (umbrellaList.isEmpty())
+            throw new IllegalStateException("가능한 남은 우산이 없습니다.");
+
+        Umbrella umbrella = umbrellaList.get(0);
+        umbrella.updateAvailable(false);
+
+        return umbrella;
     }
 }


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] History 엔티티 컬럼 추가 (endShop, clearedAt) 
- [x] HistoryRes (History 응답 DTO) 설계
- [x] 손님 우산 대여 기록 목록 조회, 손님 우산 대여, 손님 우산 반납 로직 처리  

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- `History` 엔티티에 `endShop`과 `clearedAt`을 추가로 두었습니다. `endShop`은 최종 반환한 `Shop`, `clearedAt`은 최종 `CLEAR` 된 시점을 뜻합니다.
- `History`를 만드는 과정에서 만약 가능한 우산이 없다면 `UmbrellaService`의 `getAnyFreeUmbrella`에 따라 예외가 발생합니다.
- `History`를 만들었을 때는 `endShop`이 정해지지 않았으므로 `HistoryRes`의 `endShop`에도 `null`이 저장됩니다.
- 손님이 우산을 반환하려고 할 때는 우선 아직 `CLEAR`되지 않은 `History`를 가지고 있는지 검증합니다.
- 처리할 `History`는 첫 번째 `History`로 설정했습니다.
- 만약 반납하고자 할 `Shop`이 여유 우산 공간이 없다면 예외가 발생합니다.
- 빌렸던 `Shop`이 우산을 추가로 받을 수 있다면 임시로 `endShop`을 해당 `Shop`으로 설정합니다. 이후 다른 지점임이 확인되면서 해당 지점에서도 여유 공간이 있을 경우에만 `endShop`을 새롭게 변경합니다. (또한, 이 과정에서 `Umbrella`의 소유 `Shop`이 변경되며 해당 우산은 이용 가능한 상태로 전환됩니다.)
- 반납한 뒤에는 `clearedAt` 값이 설정됩니다.
- 지금까지 대여한 목록을 조회할 때 쓰일 `endShop`은 `history.getEndShop()`에 의존됩니다.


## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->