### PR TITLE
[FEAT] 비밀번호 변경 시 새 비밀번호를 재입력하도록 설정

### DIFF
--- a/src/main/java/umc/parasol/domain/member/application/MemberService.java
+++ b/src/main/java/umc/parasol/domain/member/application/MemberService.java
@@ -31,6 +31,11 @@ public class MemberService {
         validateOriginPassword(oldPw, user.getPassword());
 
         String newPw = updatePwReq.getNewPw();
+        String reNewPw = updatePwReq.getReNewPw();
+
+        if (!newPw.equals(reNewPw))
+            throw new IllegalStateException("새로 입력한 비밀번호가 서로 일치하지 않습니다.");
+
         Member findMember = memberRepository.findById(user.getId()).orElseThrow(
                 () -> new IllegalStateException("해당 member가 없습니다.")
         );

--- a/src/main/java/umc/parasol/domain/member/dto/UpdatePwReq.java
+++ b/src/main/java/umc/parasol/domain/member/dto/UpdatePwReq.java
@@ -12,6 +12,9 @@ public class UpdatePwReq {
     @NotBlank(message = "새 비밀번호를 입력해야 합니다.")
     private String newPw;
 
+    @NotBlank(message = "새 비밀번호를 다시 입력해야 합니다.")
+    private String reNewPw;
+
     @NotBlank(message = "refresh token을 입력해야 합니다.")
     private String refreshToken;
 }


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 비밀번호 변경 시 새 비밀번호를 재입력하도록 설정 

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- `String reNewPw`를 이용해 비밀번호 변경 시 새 비밀번호를 다시 입력하도록 하였습니다.


## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
- 
