### PR TITLE
[FIX] History 기록 조회 시 대여일이 현재보다 가까운 순으로 정렬되도록 수정

### DIFF
--- a/src/main/java/umc/parasol/domain/history/application/HistoryService.java
+++ b/src/main/java/umc/parasol/domain/history/application/HistoryService.java
@@ -84,6 +84,31 @@ public class HistoryService {
         return new ApiResponse(true, historyResList);
     }
 
+
+    // 손님의 현재 대여 현황 조회
+    public ApiResponse rentalStatus(@CurrentUser UserPrincipal user){
+        Member member = findMemberById(user.getId());
+        List<History> historyList = historyRepository.findAllByMemberOrderByCreatedAtDesc(member);
+
+        //대여 내역이 존재하지 않을 때
+        if(historyList.size() == 0) {
+            return new ApiResponse(true, null);
+        }
+
+        History recentRental = historyList.get(0); //제일 최근 빌린 내역
+        Process rentalProcess = recentRental.getProcess(); //해당 내역의 상태
+
+        //현재 대여중이 아닌 경우: null
+        if(rentalProcess == Process.CLEAR) {
+            return new ApiResponse(true, null);
+        } //대여중인 경우
+        else {
+            HistoryRes recentHistory = makeHistoryRes(member, recentRental, null);
+            return new ApiResponse(true, recentHistory);
+        }
+    }
+
+
     private Shop findShopById(Long shopId) {
         return shopRepository.findById(shopId).orElseThrow(
                 () -> new IllegalStateException("해당 shop이 없습니다.")

--- a/src/main/java/umc/parasol/domain/history/application/HistoryService.java
+++ b/src/main/java/umc/parasol/domain/history/application/HistoryService.java
@@ -47,7 +47,7 @@ public class HistoryService {
     public ApiResponse returnUmbrella(@CurrentUser UserPrincipal user, Long shopId) {
         Member member = findMemberById(user.getId());
 
-        List<History> remainHistoryList = historyRepository.findAllByMember(member)
+        List<History> remainHistoryList = historyRepository.findAllByMemberOrderByCreatedAtDesc(member)
                 .stream()
                 .filter(history -> history.getProcess() != Process.CLEAR).toList();
 
@@ -75,7 +75,7 @@ public class HistoryService {
     // 손님의 대여 기록들 조회
     public ApiResponse historyList(@CurrentUser UserPrincipal user) {
         Member member = findMemberById(user.getId());
-        List<History> historyList = historyRepository.findAllByMember(member);
+        List<History> historyList = historyRepository.findAllByMemberOrderByCreatedAtDesc(member);
         List<HistoryRes> historyResList = new ArrayList<>();
         for (History history : historyList) {
             historyResList.add(makeHistoryRes(member, history, null));

--- a/src/main/java/umc/parasol/domain/history/domain/repository/HistoryRepository.java
+++ b/src/main/java/umc/parasol/domain/history/domain/repository/HistoryRepository.java
@@ -7,5 +7,5 @@ import umc.parasol.domain.member.domain.Member;
 import java.util.List;
 
 public interface HistoryRepository extends JpaRepository<History, Long> {
-    List<History> findAllByMember(Member member);
+    List<History> findAllByMemberOrderByCreatedAtDesc(Member member);
 }

--- a/src/main/java/umc/parasol/domain/history/presentation/HistoryController.java
+++ b/src/main/java/umc/parasol/domain/history/presentation/HistoryController.java
@@ -42,4 +42,14 @@ public class HistoryController {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
     }
+
+    // 손님의 현재 대여 현황
+    @GetMapping("/now")
+    public ResponseEntity<?> currentRental(@CurrentUser UserPrincipal user) {
+        try {
+            return ResponseEntity.ok(historyService.rentalStatus(user));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] History 정렬 기준 적용

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- 스프링 데이터 JPA를 활용하여 createdAt 기준으로 현재 날짜와 가까운 순서대로 (최근 순서대로) 정렬되도록 하였습니다.


## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
