### PR TITLE
[FEAT] 회원 탈퇴 기능 추가

### DIFF
--- a/src/main/java/umc/parasol/domain/history/domain/repository/HistoryRepository.java
+++ b/src/main/java/umc/parasol/domain/history/domain/repository/HistoryRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 
 public interface HistoryRepository extends JpaRepository<History, Long> {
     List<History> findAllByMemberOrderByCreatedAtDesc(Member member);
+    List<History> findAllByMember(Member member);
 }

--- a/src/main/java/umc/parasol/domain/member/application/MemberService.java
+++ b/src/main/java/umc/parasol/domain/member/application/MemberService.java
@@ -7,11 +7,21 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.parasol.domain.auth.application.AuthSignService;
 import umc.parasol.domain.auth.dto.RefreshTokenReq;
+import umc.parasol.domain.common.Status;
+import umc.parasol.domain.history.domain.History;
+import umc.parasol.domain.history.domain.Process;
+import umc.parasol.domain.history.domain.repository.HistoryRepository;
 import umc.parasol.domain.member.domain.Member;
+import umc.parasol.domain.member.domain.Role;
 import umc.parasol.domain.member.domain.repository.MemberRepository;
 import umc.parasol.domain.member.dto.UpdatePwReq;
+import umc.parasol.domain.shop.domain.Shop;
+import umc.parasol.domain.umbrella.domain.Umbrella;
+import umc.parasol.domain.umbrella.domain.repository.UmbrellaRepository;
 import umc.parasol.global.config.security.token.UserPrincipal;
 import umc.parasol.global.payload.ApiResponse;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +31,8 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final AuthSignService authSignService;
+    private final HistoryRepository historyRepository;
+    private final UmbrellaRepository umbrellaRepository;
 
     // 비밀번호 변경
     @Transactional
@@ -55,12 +67,79 @@ public class MemberService {
     }
 
     // 회원 탈퇴
-    public void deleteMember(UserPrincipal userPrincipal) {
-        // 미반납 우산이 있거나, 미납된 연체료가 있는 회원은 탈퇴가 불가 (예외처리)
+    @Transactional
+    public ApiResponse deleteMember(UserPrincipal member) {
+        Member targetMember = findMemberById(member.getId());
+        // 일반 회원일 시 : 미반납 우산이 있거나 미납된 연체료가 있는 회원은 탈퇴가 불가
+        // 미반납 우산과 미납 연체료는 모두 History로부터 조회
+        validateIsCustomerAndDeleteMember(targetMember);
+
+        // 점주일 시
+        validateIsOwnerAndDeleteMember(targetMember);
+
+        targetMember.updateStatus(Status.DELETE);
+        return new ApiResponse(true, "탈퇴 완료");
+    }
+
+    @Transactional
+    void validateIsOwnerAndDeleteMember(Member targetMember) {
+        if (isOwner(targetMember)) {
+            // 해당 Shop으로 등록된 사용중인 우산이 없어야 함
+            Shop targetShop = targetMember.getShop();
+            List<Umbrella> umbrellas = umbrellaRepository.findAllByShop(targetShop);
+            validateIsEmptyUseStateUmbrella(umbrellas);
+            umbrellas.forEach(umbrella -> umbrella.updateStatus(Status.DELETE));
+            targetShop.updateStatus(Status.DELETE);
+        }
+    }
+
+    @Transactional
+    void validateIsCustomerAndDeleteMember(Member targetMember) {
+        if (isCustomer(targetMember)) {
+            List<History> histories = historyRepository.findAllByMember(targetMember);
+            validateIsEmptyUseStateHistory(histories);
+            validateIsEmptyDelayStateHistory(histories);
+            histories.forEach(history -> history.updateStatus(Status.DELETE));
+        }
+    }
+
+    private static void validateIsEmptyUseStateUmbrella(List<Umbrella> umbrellas) {
+        List<Umbrella> unAvailableList = umbrellas.stream()
+                .filter(umbrella -> !umbrella.isAvailable()).toList();
+        if (!unAvailableList.isEmpty())
+            throw new IllegalStateException("사용 중인 우산이 있습니다.");
+    }
+
+    private static void validateIsEmptyDelayStateHistory(List<History> histories) {
+        List<History> delayHistory = histories.stream()
+                .filter(history -> history.getProcess() == Process.DELAY).toList();
+        if (!delayHistory.isEmpty())
+            throw new IllegalStateException("미납된 이용 내역이 있습니다.");
+    }
+
+    private static void validateIsEmptyUseStateHistory(List<History> histories) {
+        List<History> usingHistory = histories.stream()
+                .filter(history -> history.getProcess() == Process.USE).toList();
+        if (!usingHistory.isEmpty())
+            throw new IllegalStateException("아직 처리되지 않은 이용 내역이 있습니다.");
     }
 
     private void validateOriginPassword(String checkPassword, String password) {
         if (!BCrypt.checkpw(checkPassword, password))
             throw new IllegalStateException("비밀번호가 일치하지 않습니다.");
+    }
+
+    private Member findMemberById(Long id) {
+        return memberRepository.findById(id).orElseThrow(
+                () -> new IllegalStateException("해당 member가 없습니다.")
+        );
+    }
+
+    private boolean isCustomer(Member member) {
+        return member.getRole() == Role.CUSTOMER;
+    }
+
+    private boolean isOwner(Member member) {
+        return member.getRole() == Role.OWNER;
     }
 }

--- a/src/main/java/umc/parasol/domain/member/presentation/MemberController.java
+++ b/src/main/java/umc/parasol/domain/member/presentation/MemberController.java
@@ -3,10 +3,7 @@ package umc.parasol.domain.member.presentation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import umc.parasol.domain.member.application.MemberService;
 import umc.parasol.domain.member.dto.UpdatePwReq;
 import umc.parasol.global.config.security.token.CurrentUser;
@@ -21,5 +18,10 @@ public class MemberController {
     public ResponseEntity<?> changePassword(@Valid @RequestBody UpdatePwReq updatePwReq,
                                             @CurrentUser UserPrincipal user) {
         return ResponseEntity.ok(memberService.updatePassword(updatePwReq, user));
+    }
+
+    @DeleteMapping("/leave")
+    public ResponseEntity<?> leave(@CurrentUser UserPrincipal user) {
+        return ResponseEntity.ok(memberService.deleteMember(user));
     }
 }


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 회원 탈퇴 기능 추가

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- 일반 손님, 점주 모두 동일한 API를 사용하도록 하였습니다.
- 일반 손님인지, 점주인지에 따라 실행되는 메서드가 다릅니다.
- 일반 손님의 탈퇴 처리 기준은 History가 가진 PROCESS의 Process가 USE, DELAY인 것이 있는지를 기준으로 판단하였습니다.
- 점주의 탈퇴 처리 기준은 점주가 가진 우산들의 Available이 false인 것이 있는지를 기준으로 판단하였습니다.
- 기능 개발 과정에서 메서드 분리를 해 두었습니다.

## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
