### PR TITLE
[FIX] 반납 지점 같을 시 종료 지점 설정 오류 해결

### DIFF
--- a/src/main/java/umc/parasol/domain/history/application/HistoryService.java
+++ b/src/main/java/umc/parasol/domain/history/application/HistoryService.java
@@ -65,9 +65,9 @@ public class HistoryService {
 
         if (originShop != targetShop) { // 빌렸던 Shop과 다르다면
             targetUmbrella.updateShop(targetShop);
-            targetHistory.updateEndShop(targetShop);
         }
         targetHistory.updateClearedAt(LocalDateTime.now());
+        targetHistory.updateEndShop(targetShop);
         HistoryRes record = makeHistoryRes(member, targetHistory, targetShop);
         return new ApiResponse(true, record);
     }


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 대여 지점과 반납 지점이 같을 시 종료 지점 설정을 하지 않았던 오류를 해결했습니다.

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->


## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
