### PR TITLE
[FIX] 내역 조회 시 endShop이 전부 null로 저장되는 문제 해결

### DIFF
--- a/src/main/java/umc/parasol/domain/history/application/HistoryService.java
+++ b/src/main/java/umc/parasol/domain/history/application/HistoryService.java
@@ -78,7 +78,7 @@ public class HistoryService {
         List<History> historyList = historyRepository.findAllByMemberOrderByCreatedAtDesc(member);
         List<HistoryRes> historyResList = new ArrayList<>();
         for (History history : historyList) {
-            historyResList.add(makeHistoryRes(member, history, null));
+            historyResList.add(makeHistoryRes(member, history, history.getEndShop()));
         }
 
         return new ApiResponse(true, historyResList);


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 유저의 히스토리 내역 조회 시 endShop이 전부 null로 바뀌는 문제를 해결했습니다.

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->

## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
