### PR TITLE
[FEAT] 손님 판매한 우산 내역 조회 기능 추가

### DIFF
--- a/src/main/java/umc/parasol/domain/sell/domain/repository/SellRepository.java
+++ b/src/main/java/umc/parasol/domain/sell/domain/repository/SellRepository.java
@@ -1,8 +1,12 @@
 package umc.parasol.domain.sell.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import umc.parasol.domain.history.domain.History;
+import umc.parasol.domain.member.domain.Member;
 import umc.parasol.domain.sell.domain.Sell;
 
-public interface SellRepository extends JpaRepository<Sell, Long> {
+import java.util.List;
 
+public interface SellRepository extends JpaRepository<Sell, Long> {
+    List<Sell> findByMemberId(Long memberId);
 }

--- a/src/main/java/umc/parasol/domain/sell/dto/SellHistoryRes.java
+++ b/src/main/java/umc/parasol/domain/sell/dto/SellHistoryRes.java
@@ -1,0 +1,25 @@
+package umc.parasol.domain.sell.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Getter
+@NoArgsConstructor
+public class SellHistoryRes {
+    private String sellShop; // 판매한 매장 이름
+    private LocalDateTime createdAt; // 판매 시각
+    private Long umbrellaCount;
+
+    @Builder
+    public SellHistoryRes(String sellShop, LocalDateTime createdAt,
+                          Long umbrellaCount) {
+        this.sellShop = sellShop;
+        this.createdAt = createdAt;
+        this.umbrellaCount = umbrellaCount;
+    }
+}

--- a/src/main/java/umc/parasol/domain/umbrella/application/UmbrellaService.java
+++ b/src/main/java/umc/parasol/domain/umbrella/application/UmbrellaService.java
@@ -3,15 +3,24 @@ package umc.parasol.domain.umbrella.application;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.parasol.domain.history.domain.History;
+import umc.parasol.domain.history.dto.HistoryRes;
 import umc.parasol.domain.member.domain.Member;
 import umc.parasol.domain.member.domain.repository.MemberRepository;
+import umc.parasol.domain.sell.domain.Sell;
+import umc.parasol.domain.sell.domain.repository.SellRepository;
+import umc.parasol.domain.sell.dto.SellHistoryRes;
+import umc.parasol.domain.sell.dto.SellResultRes;
 import umc.parasol.domain.shop.domain.Shop;
 import umc.parasol.domain.shop.domain.repository.ShopRepository;
 import umc.parasol.domain.umbrella.domain.Umbrella;
 import umc.parasol.domain.umbrella.domain.repository.UmbrellaRepository;
+import umc.parasol.global.config.security.token.CurrentUser;
 import umc.parasol.global.config.security.token.UserPrincipal;
 import umc.parasol.global.payload.ApiResponse;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -23,6 +32,7 @@ public class UmbrellaService {
     private final UmbrellaRepository umbrellaRepository;
     private final MemberRepository memberRepository;
     private final ShopRepository shopRepository;
+    private final SellRepository sellRepository;
 
     @Transactional
     // 우산 개수 추가
@@ -79,4 +89,34 @@ public class UmbrellaService {
 
         return umbrella;
     }
+
+
+    //손님이 여태까지 판매한 우산 조회
+    public ApiResponse sellList(@CurrentUser UserPrincipal user){
+        Member member = getMember(user);
+        List<Sell> sellList = sellRepository.findByMemberId(member.getId());
+        List<SellHistoryRes> historyResList = new ArrayList<>();
+
+        if(sellList.isEmpty()){ //판매 내역이 존재하지 않음
+            return new ApiResponse(true, null);
+        }
+        else {
+            for (Sell sell : sellList) {
+                historyResList.add(makeSellHistoryRes(sell));
+            }
+            return new ApiResponse(true, historyResList);
+        }
+    }
+
+
+    private SellHistoryRes makeSellHistoryRes(Sell sell) {
+        return SellHistoryRes.builder()
+                .sellShop(sell.getShop().getName())
+                .createdAt(sell.getCreatedAt())
+                .umbrellaCount(1L)
+                .build();
+    }
+
 }
+
+

--- a/src/main/java/umc/parasol/domain/umbrella/presentation/UmbrellaController.java
+++ b/src/main/java/umc/parasol/domain/umbrella/presentation/UmbrellaController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import umc.parasol.domain.umbrella.application.UmbrellaService;
+import umc.parasol.domain.umbrella.domain.Umbrella;
 import umc.parasol.domain.umbrella.dto.UmbrellaAddReq;
 import umc.parasol.global.config.security.token.CurrentUser;
 import umc.parasol.global.config.security.token.UserPrincipal;
@@ -20,6 +21,16 @@ public class UmbrellaController {
     public ResponseEntity<?> add(@CurrentUser UserPrincipal user, @RequestBody UmbrellaAddReq req) {
         try {
             return ResponseEntity.ok(umbrellaService.addUmbrella(user, req.getCount()));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+    @GetMapping ("/sell")
+    //판매한 우산 찾기
+    public ResponseEntity<?> sellHistory(@CurrentUser UserPrincipal user){
+        try {
+            return ResponseEntity.ok(umbrellaService.sellList(user));
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 손님이 여태까지 판매한 우산 내역을 확인할 수 있는 기능을 작성했습니다. 

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- API 명세서 URL에 따라 UmbrellaService에 작업했고, Sell 테이블에 접근해야 하기 때문에 SellRepository를 조금 수정했습니다.
- SellHistoryRes를 만들어 반환할 데이터 정제를 쉽게 만들었습니다.
- 현재 <판매 기능>에서 판매할 우산 개수를 따로 받고 있지 않아, 저도 우선 판매한 우산 개수에 1을 넣어놓았습니다. 추후 해당 기능이 변경되면 제 코드도 변경될 예정입니다.


## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
- https://devmoony.tistory.com/132 : 메소드 쉽게 만드는 법을 알게 되었습니다.
- 참고로 다른 브랜치에서 commit을 먼저 한 상황이라 https://velog.io/@mayinjanuary/git-%EB%A1%9C%EC%BB%AC%EC%97%90%EC%84%9C-commit-%ED%95%9C-%EB%82%B4%EC%97%AD-%EC%83%88%EB%A1%9C%EC%9A%B4-%EB%B8%8C%EB%9E%9C%EC%B9%98%EB%A1%9C-%EC%98%AE%EA%B8%B0%EA%B8%B0 을 보고 따라했는데, 중간에 작성한 코드가 다 날라갔습니다. 메모장에 코드 복붙해놔서 해결(?)되었습니다..
