### PR TITLE
[FIX] 손님 판매한 우산 개수 조회 로직 수정

### DIFF
--- a/src/main/java/umc/parasol/domain/sell/application/SellService.java
+++ b/src/main/java/umc/parasol/domain/sell/application/SellService.java
@@ -8,14 +8,21 @@ import umc.parasol.domain.member.domain.Role;
 import umc.parasol.domain.member.domain.repository.MemberRepository;
 import umc.parasol.domain.sell.domain.Sell;
 import umc.parasol.domain.sell.domain.repository.SellRepository;
+import umc.parasol.domain.sell.dto.SellHistoryRes;
 import umc.parasol.domain.sell.dto.SellResultRes;
 import umc.parasol.domain.shop.domain.Shop;
 import umc.parasol.domain.shop.domain.repository.ShopRepository;
 import umc.parasol.domain.umbrella.domain.Umbrella;
 import umc.parasol.domain.umbrella.domain.repository.UmbrellaRepository;
 import umc.parasol.global.DefaultAssert;
+import umc.parasol.global.config.security.token.CurrentUser;
 import umc.parasol.global.config.security.token.UserPrincipal;
-import java.util.Optional;
+import umc.parasol.global.payload.ApiResponse;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -56,6 +63,54 @@ public class SellService {
                 .build();
 
     }
+
+
+    //손님이 여태까지 판매한 우산 조회
+    public ApiResponse sellList(@CurrentUser UserPrincipal user){
+        Member member = getCustomer(user);
+        List<Sell> sellList = sellRepository.findAllByMemberIdOrderByCreatedAtDesc(member.getId());
+        List<SellHistoryRes> historyResList = new ArrayList<>(); //중복 있는 리스트
+        List<SellHistoryRes> resultList = new ArrayList<>(); //반환할 리스트(중복제거)
+
+        if(sellList.isEmpty()){ //판매 내역이 존재하지 않음
+            return new ApiResponse(true, null);
+        }
+        else {
+            for (Sell sell : sellList) {
+                historyResList.add(makeSellHistoryRes(sell, 1L));
+            }
+            Map<SellHistoryRes, Long> historyMap = historyResList.stream().collect(
+                    Collectors.toMap(Function.identity(), value -> 1L, Long::sum));
+
+            for (SellHistoryRes res : historyMap.keySet()) {
+                resultList.add(makeSellHistoryRes(res.getSellShop(), res.getCreatedAt(), historyMap.get(res)));
+            }
+
+            //시간 순 정렬
+            List<SellHistoryRes> sortedResultList = resultList.stream()
+                    .sorted(Comparator.comparing(SellHistoryRes::getCreatedAt)).collect(Collectors.toList());
+
+            return new ApiResponse(true, sortedResultList);
+        }
+    }
+
+
+    private SellHistoryRes makeSellHistoryRes(Sell sell, Long count) {
+        return SellHistoryRes.builder()
+                .sellShop(sell.getShop().getName())
+                .createdAt(sell.getCreatedAt().toString().substring(0, 10))
+                .umbrellaCount(count)
+                .build();
+    }
+
+    private SellHistoryRes makeSellHistoryRes(String shopName, String time, Long count) {
+        return SellHistoryRes.builder()
+                .sellShop(shopName)
+                .createdAt(time)
+                .umbrellaCount(count)
+                .build();
+    }
+
 
     // 현재 로그인 한 멤버를 가져오는 메서드, 사장님이면 예외 처리
     private Member getCustomer(UserPrincipal user) {

--- a/src/main/java/umc/parasol/domain/sell/application/SellService.java
+++ b/src/main/java/umc/parasol/domain/sell/application/SellService.java
@@ -19,7 +19,6 @@ import umc.parasol.global.config.security.token.CurrentUser;
 import umc.parasol.global.config.security.token.UserPrincipal;
 import umc.parasol.global.payload.ApiResponse;
 
-import java.time.LocalDateTime;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -75,23 +74,22 @@ public class SellService {
         if(sellList.isEmpty()){ //판매 내역이 존재하지 않음
             return new ApiResponse(true, null);
         }
-        else {
-            for (Sell sell : sellList) {
-                historyResList.add(makeSellHistoryRes(sell, 1L));
-            }
-            Map<SellHistoryRes, Long> historyMap = historyResList.stream().collect(
-                    Collectors.toMap(Function.identity(), value -> 1L, Long::sum));
-
-            for (SellHistoryRes res : historyMap.keySet()) {
-                resultList.add(makeSellHistoryRes(res.getSellShop(), res.getCreatedAt(), historyMap.get(res)));
-            }
-
-            //시간 순 정렬
-            List<SellHistoryRes> sortedResultList = resultList.stream()
-                    .sorted(Comparator.comparing(SellHistoryRes::getCreatedAt)).collect(Collectors.toList());
-
-            return new ApiResponse(true, sortedResultList);
+        for (Sell sell : sellList) {
+            historyResList.add(makeSellHistoryRes(sell, 1L));
         }
+        Map<SellHistoryRes, Long> historyMap = historyResList.stream().collect(
+                Collectors.toMap(Function.identity(), value -> 1L, Long::sum));
+
+        for (SellHistoryRes res : historyMap.keySet()) {
+            resultList.add(makeSellHistoryRes(res.getSellShop(), res.getCreatedAt(), historyMap.get(res)));
+        }
+
+        //시간 순 정렬
+        List<SellHistoryRes> sortedResultList = resultList.stream()
+                .sorted(Comparator.comparing(SellHistoryRes::getCreatedAt)).collect(Collectors.toList());
+
+        return new ApiResponse(true, sortedResultList);
+
     }
 
 

--- a/src/main/java/umc/parasol/domain/sell/domain/repository/SellRepository.java
+++ b/src/main/java/umc/parasol/domain/sell/domain/repository/SellRepository.java
@@ -1,8 +1,12 @@
 package umc.parasol.domain.sell.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import umc.parasol.domain.history.domain.History;
+import umc.parasol.domain.member.domain.Member;
 import umc.parasol.domain.sell.domain.Sell;
 
-public interface SellRepository extends JpaRepository<Sell, Long> {
+import java.util.List;
 
+public interface SellRepository extends JpaRepository<Sell, Long> {
+    List<Sell> findByMemberId(Long memberId);
 }

--- a/src/main/java/umc/parasol/domain/sell/domain/repository/SellRepository.java
+++ b/src/main/java/umc/parasol/domain/sell/domain/repository/SellRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 
 public interface SellRepository extends JpaRepository<Sell, Long> {
     List<Sell> findByMemberId(Long memberId);
+
+    List<Sell> findAllByMemberIdOrderByCreatedAtDesc(Long memberId); //내림차순(최근-과거)
 }

--- a/src/main/java/umc/parasol/domain/sell/dto/SellHistoryRes.java
+++ b/src/main/java/umc/parasol/domain/sell/dto/SellHistoryRes.java
@@ -12,11 +12,11 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class SellHistoryRes {
     private String sellShop; // 판매한 매장 이름
-    private LocalDateTime createdAt; // 판매 시각
-    private Long umbrellaCount;
+    private String createdAt; // 판매 날짜
+    private Long umbrellaCount; //우산 개수
 
     @Builder
-    public SellHistoryRes(String sellShop, LocalDateTime createdAt,
+    public SellHistoryRes(String sellShop, String createdAt,
                           Long umbrellaCount) {
         this.sellShop = sellShop;
         this.createdAt = createdAt;

--- a/src/main/java/umc/parasol/domain/sell/dto/SellHistoryRes.java
+++ b/src/main/java/umc/parasol/domain/sell/dto/SellHistoryRes.java
@@ -1,0 +1,25 @@
+package umc.parasol.domain.sell.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Getter
+@NoArgsConstructor
+public class SellHistoryRes {
+    private String sellShop; // 판매한 매장 이름
+    private LocalDateTime createdAt; // 판매 시각
+    private Long umbrellaCount;
+
+    @Builder
+    public SellHistoryRes(String sellShop, LocalDateTime createdAt,
+                          Long umbrellaCount) {
+        this.sellShop = sellShop;
+        this.createdAt = createdAt;
+        this.umbrellaCount = umbrellaCount;
+    }
+}

--- a/src/main/java/umc/parasol/domain/sell/presentation/SellController.java
+++ b/src/main/java/umc/parasol/domain/sell/presentation/SellController.java
@@ -2,10 +2,7 @@ package umc.parasol.domain.sell.presentation;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import umc.parasol.domain.sell.application.SellService;
 import umc.parasol.domain.sell.dto.SellResultRes;
 import umc.parasol.global.config.security.token.CurrentUser;
@@ -33,5 +30,15 @@ public class SellController {
                 .build();
 
         return ResponseEntity.ok(apiResponse);
+    }
+
+    @GetMapping
+    //판매한 우산 찾기
+    public ResponseEntity<?> sellHistory(@CurrentUser UserPrincipal user){
+        try {
+            return ResponseEntity.ok(sellService.sellList(user));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
     }
 }

--- a/src/main/java/umc/parasol/domain/umbrella/application/UmbrellaService.java
+++ b/src/main/java/umc/parasol/domain/umbrella/application/UmbrellaService.java
@@ -91,32 +91,6 @@ public class UmbrellaService {
     }
 
 
-    //손님이 여태까지 판매한 우산 조회
-    public ApiResponse sellList(@CurrentUser UserPrincipal user){
-        Member member = getMember(user);
-        List<Sell> sellList = sellRepository.findByMemberId(member.getId());
-        List<SellHistoryRes> historyResList = new ArrayList<>();
-
-        if(sellList.isEmpty()){ //판매 내역이 존재하지 않음
-            return new ApiResponse(true, null);
-        }
-        else {
-            for (Sell sell : sellList) {
-                historyResList.add(makeSellHistoryRes(sell));
-            }
-            return new ApiResponse(true, historyResList);
-        }
-    }
-
-
-    private SellHistoryRes makeSellHistoryRes(Sell sell) {
-        return SellHistoryRes.builder()
-                .sellShop(sell.getShop().getName())
-                .createdAt(sell.getCreatedAt())
-                .umbrellaCount(1L)
-                .build();
-    }
-
 }
 
 

--- a/src/main/java/umc/parasol/domain/umbrella/application/UmbrellaService.java
+++ b/src/main/java/umc/parasol/domain/umbrella/application/UmbrellaService.java
@@ -3,24 +3,15 @@ package umc.parasol.domain.umbrella.application;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import umc.parasol.domain.history.domain.History;
-import umc.parasol.domain.history.dto.HistoryRes;
 import umc.parasol.domain.member.domain.Member;
 import umc.parasol.domain.member.domain.repository.MemberRepository;
-import umc.parasol.domain.sell.domain.Sell;
-import umc.parasol.domain.sell.domain.repository.SellRepository;
-import umc.parasol.domain.sell.dto.SellHistoryRes;
-import umc.parasol.domain.sell.dto.SellResultRes;
 import umc.parasol.domain.shop.domain.Shop;
 import umc.parasol.domain.shop.domain.repository.ShopRepository;
 import umc.parasol.domain.umbrella.domain.Umbrella;
 import umc.parasol.domain.umbrella.domain.repository.UmbrellaRepository;
-import umc.parasol.global.config.security.token.CurrentUser;
 import umc.parasol.global.config.security.token.UserPrincipal;
 import umc.parasol.global.payload.ApiResponse;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -32,7 +23,6 @@ public class UmbrellaService {
     private final UmbrellaRepository umbrellaRepository;
     private final MemberRepository memberRepository;
     private final ShopRepository shopRepository;
-    private final SellRepository sellRepository;
 
     @Transactional
     // 우산 개수 추가

--- a/src/main/java/umc/parasol/domain/umbrella/application/UmbrellaService.java
+++ b/src/main/java/umc/parasol/domain/umbrella/application/UmbrellaService.java
@@ -3,15 +3,24 @@ package umc.parasol.domain.umbrella.application;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.parasol.domain.history.domain.History;
+import umc.parasol.domain.history.dto.HistoryRes;
 import umc.parasol.domain.member.domain.Member;
 import umc.parasol.domain.member.domain.repository.MemberRepository;
+import umc.parasol.domain.sell.domain.Sell;
+import umc.parasol.domain.sell.domain.repository.SellRepository;
+import umc.parasol.domain.sell.dto.SellHistoryRes;
+import umc.parasol.domain.sell.dto.SellResultRes;
 import umc.parasol.domain.shop.domain.Shop;
 import umc.parasol.domain.shop.domain.repository.ShopRepository;
 import umc.parasol.domain.umbrella.domain.Umbrella;
 import umc.parasol.domain.umbrella.domain.repository.UmbrellaRepository;
+import umc.parasol.global.config.security.token.CurrentUser;
 import umc.parasol.global.config.security.token.UserPrincipal;
 import umc.parasol.global.payload.ApiResponse;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -23,6 +32,7 @@ public class UmbrellaService {
     private final UmbrellaRepository umbrellaRepository;
     private final MemberRepository memberRepository;
     private final ShopRepository shopRepository;
+    private final SellRepository sellRepository;
 
     @Transactional
     // 우산 개수 추가
@@ -79,4 +89,34 @@ public class UmbrellaService {
 
         return umbrella;
     }
+
+
+    //손님이 여태까지 판매한 우산 조회
+    public ApiResponse sellList(@CurrentUser UserPrincipal user){
+        Member member = getMember(user);
+        List<Sell> sellList = sellRepository.findByMemberId(member.getId());
+        List<SellHistoryRes> historyResList = new ArrayList<>();
+
+        if(sellList.isEmpty()){ //판매 내역이 존재하지 않음
+            return new ApiResponse(true, null);
+        }
+        else {
+            for (Sell sell : sellList) {
+                historyResList.add(makeSellHistoryRes(sell));
+            }
+            return new ApiResponse(true, historyResList);
+        }
+    }
+
+
+    private SellHistoryRes makeSellHistoryRes(Sell sell) {
+        return SellHistoryRes.builder()
+                .sellShop(sell.getShop().getName())
+                .createdAt(sell.getCreatedAt())
+                .umbrellaCount(1L)
+                .build();
+    }
+
 }
+
+

--- a/src/main/java/umc/parasol/domain/umbrella/presentation/UmbrellaController.java
+++ b/src/main/java/umc/parasol/domain/umbrella/presentation/UmbrellaController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import umc.parasol.domain.umbrella.application.UmbrellaService;
+import umc.parasol.domain.umbrella.domain.Umbrella;
 import umc.parasol.domain.umbrella.dto.UmbrellaAddReq;
 import umc.parasol.global.config.security.token.CurrentUser;
 import umc.parasol.global.config.security.token.UserPrincipal;
@@ -20,6 +21,16 @@ public class UmbrellaController {
     public ResponseEntity<?> add(@CurrentUser UserPrincipal user, @RequestBody UmbrellaAddReq req) {
         try {
             return ResponseEntity.ok(umbrellaService.addUmbrella(user, req.getCount()));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+    @GetMapping ("/sell")
+    //판매한 우산 찾기
+    public ResponseEntity<?> sellHistory(@CurrentUser UserPrincipal user){
+        try {
+            return ResponseEntity.ok(umbrellaService.sellList(user));
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }

--- a/src/main/java/umc/parasol/domain/umbrella/presentation/UmbrellaController.java
+++ b/src/main/java/umc/parasol/domain/umbrella/presentation/UmbrellaController.java
@@ -26,14 +26,6 @@ public class UmbrellaController {
         }
     }
 
-    @GetMapping ("/sell")
-    //판매한 우산 찾기
-    public ResponseEntity<?> sellHistory(@CurrentUser UserPrincipal user){
-        try {
-            return ResponseEntity.ok(umbrellaService.sellList(user));
-        } catch (Exception e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
-        }
-    }
+
 
 }

--- a/src/main/java/umc/parasol/domain/umbrella/presentation/UmbrellaController.java
+++ b/src/main/java/umc/parasol/domain/umbrella/presentation/UmbrellaController.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import umc.parasol.domain.umbrella.application.UmbrellaService;
-import umc.parasol.domain.umbrella.domain.Umbrella;
 import umc.parasol.domain.umbrella.dto.UmbrellaAddReq;
 import umc.parasol.global.config.security.token.CurrentUser;
 import umc.parasol.global.config.security.token.UserPrincipal;


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 우선 기존 Umbrella 도메인에서 작업했던 내용들을 Sell로 옮겼습니다.
- [x] 기존에 판매한 우산 개수가 모두 1로 표시되었던 것을 수정하여, 같은 날짜 내 같은 매장에서 판매를 여러 번 했을 경우 우산 개수가 합산되어 반환되도록 수정했습니다.

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- makeSellHistoryRes() 메소드를 오버로딩하여 로직에 유용하게 사용하였습니다.
- 중복된 날짜의 history를 제거하고 우산 개수를 합산하는 데 Map을 사용하고, 다시 List 형태로 반환하였습니다.
- 이때 Map은 정렬 개념이 없어서 다시 시간 순으로 정렬하는 과정이 필요했습니다.


## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
- https://zangzangs.tistory.com/60 ArrayList를 특정 값으로 정렬할 때 유용하게 사용했습니다.
- https://developer-talk.tistory.com/394 Map과 List를 다룰 때 도움이 되었습니다.
