### PR TITLE
[FIX] 엔티티 직접 반환 및 프록시 이슈 해결

### DIFF
--- a/src/main/java/umc/parasol/domain/verify/application/VerifyService.java
+++ b/src/main/java/umc/parasol/domain/verify/application/VerifyService.java
@@ -14,6 +14,7 @@ import umc.parasol.domain.verify.domain.Verify;
 import umc.parasol.domain.verify.domain.repository.VerifyRepository;
 import umc.parasol.domain.verify.dto.CheckReq;
 import umc.parasol.domain.verify.dto.VerifyReq;
+import umc.parasol.domain.verify.dto.VerifyResponse;
 import umc.parasol.global.payload.ApiResponse;
 
 import java.time.LocalDateTime;
@@ -50,9 +51,14 @@ public class VerifyService {
         removePreviousVerifies(findMember);
         Verify newVerify = createVerify(code, findMember);
         verifyRepository.save(newVerify);
+        VerifyResponse response = VerifyResponse.of(
+                newVerify.getCode(),
+                findMember.getNickname(),
+                newVerify.getCreatedAt(),
+                newVerify.getExpirationTime());
         sendMessage(verifyReq, code);
 
-        return new ApiResponse(true, newVerify);
+        return new ApiResponse(true, response);
     }
 
     private void removePreviousVerifies(Member findMember) {

--- a/src/main/java/umc/parasol/domain/verify/dto/VerifyResponse.java
+++ b/src/main/java/umc/parasol/domain/verify/dto/VerifyResponse.java
@@ -1,0 +1,21 @@
+package umc.parasol.domain.verify.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class VerifyResponse {
+
+    private final int code;
+    private final String name;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime expirationTime;
+
+    public static VerifyResponse of(int code, String name, LocalDateTime createdAt, LocalDateTime expirationTime) {
+        return new VerifyResponse(code, name, createdAt, expirationTime);
+    }
+}


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 인증 요청 과정에서 (`POST /verify`) 응답으로 Verify 엔티티를 직접 가져오는 문제 해결  

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- Verify에는 Member가 있으며, Member에는 Shop이 있습니다. 그런데 Verify를 직접적으로 리턴할 경우, Member를 조회하고, 또 이어서 Shop을 조회하려고 할 때 프록시 이슈가 발생합니다. (지연 로딩으로 인한)
- 이를 통해 엔티티를 직접 반환하면 지연 로딩이 적용되어 있을 경우 프록시 이슈가 발생할 수 있다는 사실을 알게 되었습니다.

## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
