### PR TITLE
[FIX] 우산 대여 기록 관련 null 응답 empty & 다른 값으로 변경

### DIFF
--- a/src/main/java/umc/parasol/domain/history/application/HistoryService.java
+++ b/src/main/java/umc/parasol/domain/history/application/HistoryService.java
@@ -127,11 +127,11 @@ public class HistoryService {
                 .fromShop(history.getFromShop().getName())
                 .endShop((endShop == null) ?
                         (history.getEndShop() == null
-                                ? null
+                                ? ""
                                 : history.getEndShop().getName())
                         : endShop.getName())
                 .createdAt(history.getCreatedAt())
-                .clearedAt(history.getClearedAt())
+                .clearedAt(history.getClearedAt() == null ? LocalDateTime.of(9999, 12, 31, 23, 59) : history.getClearedAt())
                 .process(history.getProcess())
                 .build();
     }


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 우산 대여 기록 관련 null 응답 empty 처리 및 다른 값으로 변경

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- String 형태인 endShop은 빈 문자열로 처리했으며, LocalDateTime 형식인 clearedAt은 `9999-12-31T23:59:00`으로 설정했습니다.

## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
