### PR TITLE
[feat] ID (이메일) 복구 기능 개발

### DIFF
--- a/src/main/java/umc/parasol/domain/auth/application/AuthSignService.java
+++ b/src/main/java/umc/parasol/domain/auth/application/AuthSignService.java
@@ -135,4 +135,10 @@ public class AuthSignService {
     }
 
 
+    public RecoveryRes recovery(RecoveryReq request) {
+        Member targetMember = memberRepository.findByPhoneNumber(request.getPhoneNumber())
+                .orElseThrow(() -> new IllegalStateException("등록되지 않은 전화번호 입니다."));
+
+        return RecoveryRes.from(targetMember.getEmail(), targetMember.getNickname(), targetMember.getPhoneNumber());
+    }
 }

--- a/src/main/java/umc/parasol/domain/auth/dto/RecoveryReq.java
+++ b/src/main/java/umc/parasol/domain/auth/dto/RecoveryReq.java
@@ -1,0 +1,15 @@
+package umc.parasol.domain.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RecoveryReq {
+
+    private String phoneNumber;
+
+    public RecoveryReq(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+}

--- a/src/main/java/umc/parasol/domain/auth/dto/RecoveryReq.java
+++ b/src/main/java/umc/parasol/domain/auth/dto/RecoveryReq.java
@@ -1,5 +1,7 @@
 package umc.parasol.domain.auth.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -7,9 +9,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class RecoveryReq {
 
+    @NotBlank(message = "이름을 입력해야 합니다.")
+    private String name;
+
+    @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "핸드폰 번호의 양식과 맞지 않습니다.")
     private String phoneNumber;
 
-    public RecoveryReq(String phoneNumber) {
+    public RecoveryReq(String name, String phoneNumber) {
+        this.name = name;
         this.phoneNumber = phoneNumber;
     }
 }

--- a/src/main/java/umc/parasol/domain/auth/dto/RecoveryRes.java
+++ b/src/main/java/umc/parasol/domain/auth/dto/RecoveryRes.java
@@ -8,17 +8,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RecoveryRes {
 
+    private Long id;
     private String email;
-    private String nickname;
-    private String phoneNumber;
 
-    public static RecoveryRes from(String email, String nickname, String phoneNumber) {
-        return new RecoveryRes(email, nickname, phoneNumber);
+    public static RecoveryRes from(Long id, String email) {
+        return new RecoveryRes(id, email);
     }
 
-    private RecoveryRes(String email, String nickname, String phoneNumber) {
+    private RecoveryRes(Long id, String email) {
+        this.id = id;
         this.email = email;
-        this.nickname = nickname;
-        this.phoneNumber = phoneNumber;
     }
 }

--- a/src/main/java/umc/parasol/domain/auth/dto/RecoveryRes.java
+++ b/src/main/java/umc/parasol/domain/auth/dto/RecoveryRes.java
@@ -1,0 +1,24 @@
+package umc.parasol.domain.auth.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecoveryRes {
+
+    private String email;
+    private String nickname;
+    private String phoneNumber;
+
+    public static RecoveryRes from(String email, String nickname, String phoneNumber) {
+        return new RecoveryRes(email, nickname, phoneNumber);
+    }
+
+    private RecoveryRes(String email, String nickname, String phoneNumber) {
+        this.email = email;
+        this.nickname = nickname;
+        this.phoneNumber = phoneNumber;
+    }
+}

--- a/src/main/java/umc/parasol/domain/auth/presentation/AuthController.java
+++ b/src/main/java/umc/parasol/domain/auth/presentation/AuthController.java
@@ -106,4 +106,18 @@ public class AuthController {
 
         return ResponseEntity.ok(apiResponse);
     }
+
+    // 계정 (이메일) 복구
+    @PostMapping("/recovery")
+    public ResponseEntity<ApiResponse> recovery(@Valid @RequestBody RecoveryReq request) {
+
+        RecoveryRes recoveryRes = authService.recovery(request);
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information(recoveryRes)
+                .build();
+
+        return ResponseEntity.ok(apiResponse);
+    }
 }

--- a/src/main/java/umc/parasol/domain/auth/presentation/AuthController.java
+++ b/src/main/java/umc/parasol/domain/auth/presentation/AuthController.java
@@ -11,6 +11,8 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import umc.parasol.domain.auth.application.AuthSignService;
 import umc.parasol.domain.auth.application.AuthTokenService;
 import umc.parasol.domain.auth.dto.*;
+import umc.parasol.domain.verify.dto.CheckReq;
+import umc.parasol.domain.verify.dto.VerifyResponse;
 import umc.parasol.global.config.security.token.CurrentUser;
 import umc.parasol.global.config.security.token.UserPrincipal;
 import umc.parasol.global.payload.ApiResponse;
@@ -111,11 +113,25 @@ public class AuthController {
     @PostMapping("/recovery")
     public ResponseEntity<ApiResponse> recovery(@Valid @RequestBody RecoveryReq request) {
 
-        RecoveryRes recoveryRes = authService.recovery(request);
+        VerifyResponse response = authService.recovery(request);
 
         ApiResponse apiResponse = ApiResponse.builder()
                 .check(true)
-                .information(recoveryRes)
+                .information(response)
+                .build();
+
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    // 계정 이메일 복구 확인
+    @PostMapping("/recovery/check")
+    public ResponseEntity<ApiResponse> recoveryCheck(@Valid @RequestBody CheckReq request) {
+
+        RecoveryRes response = authService.recoveryCheck(request);
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information(response)
                 .build();
 
         return ResponseEntity.ok(apiResponse);

--- a/src/main/java/umc/parasol/domain/member/domain/repository/MemberRepository.java
+++ b/src/main/java/umc/parasol/domain/member/domain/repository/MemberRepository.java
@@ -9,6 +9,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByPhoneNumber(String phoneNumber);
     Optional<Member> findByEmail(String email);
-
+    Optional<Member> findByName(String name);
     Boolean existsByEmail(String email);
 }

--- a/src/main/java/umc/parasol/domain/verify/dto/VerifyReq.java
+++ b/src/main/java/umc/parasol/domain/verify/dto/VerifyReq.java
@@ -4,8 +4,12 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Data
+@Getter
+@NoArgsConstructor
 public class VerifyReq {
 
     @NotBlank(message = "이름을 입력해야 합니다.")
@@ -18,4 +22,9 @@ public class VerifyReq {
     @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "핸드폰 번호의 양식과 맞지 않습니다.")
     private String phoneNumber;
 
+    public VerifyReq(String name, String email, String phoneNumber) {
+        this.name = name;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+    }
 }


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] ID (이메일) 복구 기능 개발 
- [x] 요청 시 문자 인증 선행되도록 개발 

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- 기존에 미리 만든 Verify를 활용해 문자 인증을 먼저 해야만 복구할 수 있도록 하였습니다.
- 처음에 유저는 `auth/recovery`에서 자신의 이름과 전화번호를 담아 요청합니다.
- 해당 요청을 보내면 코드가 생성됩니다.
- 이제 제한 시간 내에 `auth/recovery/check`로 해당 코드와 자신의 전화번호를 담아 다시 확인용 요청을 보냅니다.
- 이후, 정상적으로 인증 처리되면 유저의 고유 id값과 이메일이 나옵니다.

## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
