### PR TITLE
[FEAT] 알림 기능 3가지(대여, 반납, 판매) 구현

### DIFF
--- a/src/main/java/umc/parasol/ParasolApplication.java
+++ b/src/main/java/umc/parasol/ParasolApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import umc.parasol.global.config.YamlPropertySourceFactory;
 
 @SpringBootApplication
 @EnableJpaAuditing
+//@EnableScheduling
 @PropertySource(value = {"classpath:database/application-database.yml"}, factory = YamlPropertySourceFactory.class)
 @PropertySource(value = {"classpath:auth/application-auth.yml"}, factory = YamlPropertySourceFactory.class)
 public class ParasolApplication {

--- a/src/main/java/umc/parasol/domain/history/application/HistoryService.java
+++ b/src/main/java/umc/parasol/domain/history/application/HistoryService.java
@@ -9,6 +9,7 @@ import umc.parasol.domain.history.dto.HistoryRes;
 import umc.parasol.domain.history.domain.repository.HistoryRepository;
 import umc.parasol.domain.member.domain.Member;
 import umc.parasol.domain.member.domain.repository.MemberRepository;
+import umc.parasol.domain.notification.application.NotificationService;
 import umc.parasol.domain.shop.domain.Shop;
 import umc.parasol.domain.shop.domain.repository.ShopRepository;
 import umc.parasol.domain.umbrella.application.UmbrellaService;
@@ -27,6 +28,7 @@ import java.util.List;
 public class HistoryService {
     private final HistoryRepository historyRepository;
     private final MemberRepository memberRepository;
+    private final NotificationService notificationService;
 
 
     // 손님의 대여 기록들 조회

--- a/src/main/java/umc/parasol/domain/history/domain/repository/HistoryRepository.java
+++ b/src/main/java/umc/parasol/domain/history/domain/repository/HistoryRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface HistoryRepository extends JpaRepository<History, Long> {
     List<History> findAllByMemberOrderByCreatedAtDesc(Member member);
     List<History> findAllByMember(Member member);
+
+    List<History> findAllByMemberOrderByCreatedAtAsc(Member member); //오름차순
 }

--- a/src/main/java/umc/parasol/domain/notification/application/NotificationService.java
+++ b/src/main/java/umc/parasol/domain/notification/application/NotificationService.java
@@ -3,6 +3,7 @@ package umc.parasol.domain.notification.application;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cglib.core.Local;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.parasol.domain.history.domain.History;
@@ -115,27 +116,28 @@ public class NotificationService {
      * 무료 대여 3시간 알림 계산 및 설정 -> 10분 마다 호출한다고 가정
      * 테스트: notificationService.threeHourLeft(user); 를 어디선가 실행해보면 됨(완료)
      */
-    @Transactional
-    public void threeHourLeft(UserPrincipal user) {
-        Member member = findMemberById(user.getId());
-        List<History> historyList = historyRepository.findAllByMemberOrderByCreatedAtAsc(member); //대여기록 오름차순 정렬
-        LocalDateTime timeNow = LocalDateTime.now(); //현재 시간
-        log.info("threeHourLeft 실행");
-        for (History history : historyList) { //제일 오래 전 대여 기록부터
-            if(history.getProcess() == Process.USE){
-                LocalDateTime timeCreated = history.getCreatedAt(); //대여 시간
-                Duration duration = Duration.between(timeCreated, timeNow);
-                // 남은 시간이 3시간 ~ 2시간 50분일 때
-                if(duration.getSeconds() >= 75600 && duration.getSeconds() < 76200) {
-                    log.info("3시간 알림 생성!");
-                    Notification notification = makeNotification(history.getFromShop(), member, NotificationType.FREE_RENTAL_END);
-                    notificationRepository.save(notification);
-                }
-            }
-        }
-
-
-    }
+//    @Transactional
+//    @Scheduled(cron = "* 0/10 * * * ?") //10분마다 해당 메소드 실행
+//    public void threeHourLeft(UserPrincipal user) {
+//        Member member = findMemberById(user.getId());
+//        List<History> historyList = historyRepository.findAllByMemberOrderByCreatedAtAsc(member); //대여기록 오름차순 정렬
+//        LocalDateTime timeNow = LocalDateTime.now(); //현재 시간
+//        log.info("threeHourLeft 실행");
+//        for (History history : historyList) { //제일 오래 전 대여 기록부터
+//            if(history.getProcess() == Process.USE){
+//                LocalDateTime timeCreated = history.getCreatedAt(); //대여 시간
+//                Duration duration = Duration.between(timeCreated, timeNow);
+//                // 남은 시간이 3시간 ~ 2시간 50분일 때
+//                if(duration.getSeconds() >= 75600 && duration.getSeconds() < 76200) {
+//                    log.info("3시간 알림 생성!");
+//                    Notification notification = makeNotification(history.getFromShop(), member, NotificationType.FREE_RENTAL_END);
+//                    notificationRepository.save(notification);
+//                }
+//            }
+//        }
+//
+//
+//    }
 
     private Member findMemberById(Long memerId) {
         return memberRepository.findById(memerId).orElseThrow(

--- a/src/main/java/umc/parasol/domain/notification/application/NotificationService.java
+++ b/src/main/java/umc/parasol/domain/notification/application/NotificationService.java
@@ -1,20 +1,25 @@
 package umc.parasol.domain.notification.application;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.parasol.domain.member.domain.Member;
 import umc.parasol.domain.member.domain.repository.MemberRepository;
 import umc.parasol.domain.notification.domain.Notification;
+import umc.parasol.domain.notification.domain.NotificationType;
 import umc.parasol.domain.notification.domain.repository.NotificationRepository;
 import umc.parasol.domain.notification.dto.NotificationRes;
+import umc.parasol.domain.shop.domain.Shop;
 import umc.parasol.global.config.security.token.UserPrincipal;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Slf4j
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
@@ -69,4 +74,33 @@ public class NotificationService {
         return true;
     }
 
+    /**
+     * 알림 생성
+     * @param targetShop 상점
+     * @param member 유저
+     * @param type 알림 종류
+     */
+    @Transactional
+    public Notification makeNotification(Shop targetShop, Member member, NotificationType type) {
+        String content = "";
+        log.info(type.toString());
+        if(type == NotificationType.RENT_COMPLETED){
+            content = "대여를 완료했어요!";
+        } else if (type == NotificationType.RETURN_COMPLETED) {
+            content = "반납을 완료했어요!";
+        } else if (type == NotificationType.SALE_COMPLETED) {
+            content = "판매를 완료했어요!";
+        } else if (type == NotificationType.FREE_RENTAL_END) {
+            content = "3시간 후 무료대여가 종료됩니다.";
+        } else if (type == NotificationType.OVERDUE_FINE) {
+            content = "사용시간 초과로 연체료 1,000원이 누적되었습니다.";
+        }
+        return Notification.builder()
+                .type(type)
+                .content(content)
+                .sentTime(LocalDateTime.now())
+                .recipient(member)
+                .shop(targetShop)
+                .build();
+    }
 }

--- a/src/main/java/umc/parasol/domain/sell/application/SellService.java
+++ b/src/main/java/umc/parasol/domain/sell/application/SellService.java
@@ -6,6 +6,10 @@ import org.springframework.transaction.annotation.Transactional;
 import umc.parasol.domain.member.domain.Member;
 import umc.parasol.domain.member.domain.Role;
 import umc.parasol.domain.member.domain.repository.MemberRepository;
+import umc.parasol.domain.notification.application.NotificationService;
+import umc.parasol.domain.notification.domain.Notification;
+import umc.parasol.domain.notification.domain.NotificationType;
+import umc.parasol.domain.notification.domain.repository.NotificationRepository;
 import umc.parasol.domain.sell.domain.Sell;
 import umc.parasol.domain.sell.domain.repository.SellRepository;
 import umc.parasol.domain.sell.dto.SellHistoryRes;
@@ -32,6 +36,8 @@ public class SellService {
     private final SellRepository sellRepository;
     private final ShopRepository shopRepository;
     private final UmbrellaRepository umbrellaRepository;
+    private final NotificationRepository notificationRepository;
+    private final NotificationService notificationService;
 
     /**
      * 우산 판매
@@ -55,6 +61,10 @@ public class SellService {
                 .build();
 
         sellRepository.save(sell);
+
+        //알림 생성
+        Notification notification = notificationService.makeNotification(targetShop, findMember, NotificationType.SALE_COMPLETED);
+        notificationRepository.save(notification);
 
         return SellResultRes.builder()
                 .shopName(targetShop.getName())

--- a/src/main/java/umc/parasol/domain/shop/application/ShopService.java
+++ b/src/main/java/umc/parasol/domain/shop/application/ShopService.java
@@ -234,6 +234,7 @@ public class ShopService {
         History history = rentalUmbrella(targetShop, member);
         historyRepository.save(history);
 
+        //알림 생성
         Notification notification = notificationService.makeNotification(targetShop, member, NotificationType.RENT_COMPLETED);
         notificationRepository.save(notification);
 
@@ -275,6 +276,7 @@ public class ShopService {
         targetHistory.updateEndShop(targetShop);
         HistoryRes record = makeHistoryRes(member, targetHistory, targetShop);
 
+        //알림 생성
         Notification notification = notificationService.makeNotification(targetShop, member, NotificationType.RETURN_COMPLETED);
         notificationRepository.save(notification);
 


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 사용자가 우산을 대여, 반납, 판매할 때 알림 테이블에 알림이 생성되도록 하였습니다.  

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- NotificationType에 따라 알림의 종류가 다릅니다. 이는 솔비님이 정의해놓으셔서 이에 따라 알림 생성 코드만 만들었습니다.
- 이 중 반납 3시간 전 알림은 메소드는 구현해놓았지만 @Scheduled 를 붙이니 오류가 떠서(인자가 있는 메소드는 스케줄링 불가인 듯 합니다) 주석처리 해놓았고, 연체료 알림은 아직 미구현입니다.


## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
- 
