### PR TITLE
[FIX] 대여/반납/판매 처리 시 유저가 선택한 매장이 맞는지 검증 로직 추가

### DIFF
--- a/src/main/java/umc/parasol/domain/sell/application/SellService.java
+++ b/src/main/java/umc/parasol/domain/sell/application/SellService.java
@@ -45,12 +45,17 @@ public class SellService {
      * @param memberId 판매할 손님 ID
      */
     @Transactional
-    public SellResultRes sellUmbrella(UserPrincipal userPrincipal, Long memberId) {
+    public SellResultRes sellUmbrella(UserPrincipal userPrincipal, Long memberId, Long shopId) {
 
         Member findOwner = getOwner(userPrincipal);
         Member findMember = getCustomer(memberId);
 
         Shop targetShop = findOwner.getShop();
+
+        //손님이 선택한 매장 맞는지 검증
+        if(targetShop.getId() != shopId) {
+            throw new IllegalStateException("손님이 선택한 매장이 아닙니다.");
+        }
 
         Umbrella newUmbrella = Umbrella.createUmbrella(targetShop);
         umbrellaRepository.save(newUmbrella);

--- a/src/main/java/umc/parasol/domain/sell/presentation/SellController.java
+++ b/src/main/java/umc/parasol/domain/sell/presentation/SellController.java
@@ -17,12 +17,13 @@ public class SellController {
     private final SellService sellService;
 
     // 우산 판매
-    @PostMapping("/{id}")
+    @PostMapping("/{userId}/{shopId}")
     public ResponseEntity<?> sellUmbrella(
             @CurrentUser UserPrincipal userPrincipal,
-            @PathVariable(value = "id") Long memberId) {
+            @PathVariable(value = "userId") Long memberId,
+            @PathVariable Long shopId) {
 
-        SellResultRes sellResultRes = sellService.sellUmbrella(userPrincipal, memberId);
+        SellResultRes sellResultRes = sellService.sellUmbrella(userPrincipal, memberId, shopId);
 
         ApiResponse apiResponse = ApiResponse.builder()
                 .check(true)

--- a/src/main/java/umc/parasol/domain/shop/application/ShopService.java
+++ b/src/main/java/umc/parasol/domain/shop/application/ShopService.java
@@ -223,12 +223,17 @@ public class ShopService {
      * @param memberId 대여자 객체
      */
     @Transactional
-    public ApiResponse rentalUmbrella(@CurrentUser UserPrincipal user, Long memberId) {
+    public ApiResponse rentalUmbrella(@CurrentUser UserPrincipal user, Long memberId, Long shopId) {
 
         Member owner = findValidMember(user.getId()); //점주
         Shop targetShop = findValidShopForOwner(owner); //점주의 shop
 
         Member member = findValidMember(memberId); //대여자
+
+        //손님이 선택한 매장 맞는지 검증
+        if(targetShop.getId() != shopId) {
+            throw new IllegalStateException("손님이 선택한 매장이 아닙니다.");
+        }
 
         History history = rentalUmbrella(targetShop, member);
         historyRepository.save(history);

--- a/src/main/java/umc/parasol/domain/shop/application/ShopService.java
+++ b/src/main/java/umc/parasol/domain/shop/application/ShopService.java
@@ -221,6 +221,7 @@ public class ShopService {
      * 우산 대여 처리
      * @param user api 호출하는 사용자 객체 (점주)
      * @param memberId 대여자 객체
+     * @param shopId url에 담긴 손님이 선택한 매장 id
      */
     @Transactional
     public ApiResponse rentalUmbrella(@CurrentUser UserPrincipal user, Long memberId, Long shopId) {
@@ -251,13 +252,19 @@ public class ShopService {
      * 우산 반납 처리
      * @param user api 호출하는 사용자 객체 (점주)
      * @param memberId 대여자 객체
+     * @param shopId 손님이 선택한 매장 id
      */
     @Transactional
-    public ApiResponse returnUmbrella(@CurrentUser UserPrincipal user, Long memberId) {
+    public ApiResponse returnUmbrella(@CurrentUser UserPrincipal user, Long memberId, Long shopId) {
         Member owner = findValidMember(user.getId()); //점주
         Shop targetShop = findValidShopForOwner(owner); //점주의 shop
 
         Member member = findValidMember(memberId); //대여자
+
+        //손님이 선택한 매장 맞는지 검증
+        if(targetShop.getId() != shopId) {
+            throw new IllegalStateException("손님이 선택한 매장이 아닙니다.");
+        }
 
         List<History> remainHistoryList = historyRepository.findAllByMemberOrderByCreatedAtDesc(member)
                 .stream()

--- a/src/main/java/umc/parasol/domain/shop/presentation/ShopController.java
+++ b/src/main/java/umc/parasol/domain/shop/presentation/ShopController.java
@@ -137,10 +137,10 @@ public class ShopController {
     }
 
     // 우산 반납
-    @PostMapping("/umbrella/return/{id}")
-    public ResponseEntity<?> returnUmbrella(@CurrentUser UserPrincipal user, @PathVariable Long id) {
+    @PostMapping("/umbrella/return/{userId}/{shopId}")
+    public ResponseEntity<?> returnUmbrella(@CurrentUser UserPrincipal user, @PathVariable Long userId, @PathVariable Long shopId) {
         try {
-            return ResponseEntity.ok(shopService.returnUmbrella(user, id));
+            return ResponseEntity.ok(shopService.returnUmbrella(user, userId, shopId));
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }

--- a/src/main/java/umc/parasol/domain/shop/presentation/ShopController.java
+++ b/src/main/java/umc/parasol/domain/shop/presentation/ShopController.java
@@ -127,10 +127,10 @@ public class ShopController {
     }
 
     // 우산 대여
-    @PostMapping("/umbrella/rental/{id}")
-    public ResponseEntity<?> rentalUmbrella(@CurrentUser UserPrincipal user, @PathVariable Long id) {
+    @PostMapping("/umbrella/rental/{userId}/{shopId}")
+    public ResponseEntity<?> rentalUmbrella(@CurrentUser UserPrincipal user, @PathVariable Long userId, @PathVariable Long shopId) {
         try {
-            return ResponseEntity.ok(shopService.rentalUmbrella(user, id));
+            return ResponseEntity.ok(shopService.rentalUmbrella(user, userId, shopId));
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 우산 대여/반납/판매 처리 시 손님이 선택한 매장과 상관없이 처리가 완료되는 부분을 수정했습니다.  

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- 손님이 만들 URL에 shopId를 같이 받아, 해당 QR을 찍는 사장님의 매장과 URL의 매장이 일치하는지 검증합니다.


## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
- 
