### PR TITLE
[FEAT] : fcmToken 업데이트 및 푸시 알림 전송 api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'com.google.firebase:firebase-admin:8.0.0'  // 최신 버전 사용
+	implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.2.2'
+
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/umc/parasol/domain/member/domain/Member.java
+++ b/src/main/java/umc/parasol/domain/member/domain/Member.java
@@ -48,7 +48,6 @@ public class Member extends BaseEntity {
     // 인증 관련 필드
     @NotNull(message = "인증 여부가 설정되어 있어야 합니다.")
     private Boolean isVerified;
-
     private String name;
 
     private String phoneNumber;
@@ -56,6 +55,9 @@ public class Member extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "shop_id")
     private Shop shop;
+
+    @Column(name = "fcm_token")
+    private String fcmToken; // FCM 토큰
 
     // update 메서드
     public void updateNickname(String nickname){this.nickname = nickname;}
@@ -70,5 +72,9 @@ public class Member extends BaseEntity {
 
     public void updateName(String name) {
         this.name = name;
+    }
+
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
     }
 }

--- a/src/main/java/umc/parasol/domain/notification/application/FirebaseCloudMessageService.java
+++ b/src/main/java/umc/parasol/domain/notification/application/FirebaseCloudMessageService.java
@@ -1,11 +1,20 @@
 package umc.parasol.domain.notification.application;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.net.HttpHeaders;
 import lombok.RequiredArgsConstructor;
+import okhttp3.*;
+import org.springframework.core.io.ClassPathResource;
+import com.google.auth.oauth2.GoogleCredentials;
 import org.springframework.stereotype.Component;
 import umc.parasol.domain.member.domain.Member;
 import umc.parasol.domain.member.domain.repository.MemberRepository;
+import umc.parasol.domain.notification.domain.FcmMessage;
 import umc.parasol.global.config.security.token.UserPrincipal;
+
+import java.io.IOException;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -13,6 +22,78 @@ public class FirebaseCloudMessageService {
     private final String API_URL = "https://fcm.googleapis.com/v1/projects/parasol-bcbf5/messages:send";
     private final ObjectMapper objectMapper;
     private final MemberRepository memberRepository;
+
+
+    /**
+     * makeMessage 메서드를 호출하여 메시지를 생성한 후, OkHttpClient를 이용하여 FCM 서버로 전송
+     * @param targetToken
+     * @param title
+     * @param body
+     * @throws IOException
+     */
+    public void sendMessageTo(String targetToken, String title, String body) throws IOException {
+        String message = makeMessage(targetToken, title, body);
+
+        OkHttpClient client = new OkHttpClient();
+        okhttp3.RequestBody requestBody = RequestBody.create(message, MediaType.get("application/json; charset=utf-8"));
+        Request request = new Request.Builder()
+                .url(API_URL)
+                .post(requestBody)
+                .addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + getAccessToken())
+                .addHeader(HttpHeaders.CONTENT_TYPE, "application/json; UTF-8")
+                .build();
+
+        Response response = client.newCall(request)
+                .execute();
+
+    }
+
+    /**
+     * targetToken, title, body 값을 매개변수로 받아서 FcmMessage 객체를 빌더 패턴을 이용하여 생성
+     * FcmMessage 객체를 생성하고, 이를 JSON 문자열로 변환하여 반환하는 역할
+     * @param targetToken
+     * @param title
+     * @param body
+     * @return
+     * @throws JsonProcessingException
+     */
+    private String makeMessage(String targetToken, String title, String body) throws JsonProcessingException {
+        FcmMessage fcmMessage = FcmMessage.builder()
+                .message(FcmMessage.Message.builder()
+                        .token(targetToken)
+                        .notification(FcmMessage.Notification.builder()
+                                .title(title)
+                                .body(body)
+                                .image(null)
+                                .build()
+                        )
+                        .build()
+                )
+                .validate_only(false)
+                .build();
+
+
+        return objectMapper.writeValueAsString(fcmMessage);
+    }
+
+    /**
+     * Firebase Admin SDK를 사용하기 위해 Google Cloud의 인증서버에서 Access Token을 얻어오는 기능 수행
+     * @return
+     * @throws IOException
+     */
+    private String getAccessToken() throws IOException {
+        String firebaseConfigPath = "firebase/firebase_service_key.json";
+
+        GoogleCredentials googleCredentials = GoogleCredentials
+                .fromStream(new ClassPathResource(firebaseConfigPath).getInputStream())
+                .createScoped(List.of("https://www.googleapis.com/auth/cloud-platform"));
+
+        googleCredentials.refreshIfExpired();
+
+        return googleCredentials.getAccessToken().getTokenValue();
+    }
+
+
 
     /**
      * 동일 user가 기존 token과 입력된 token이 달라질 경우에만 업데이트하여 저장
@@ -36,4 +117,6 @@ public class FirebaseCloudMessageService {
         );
     }
 
+
 }
+

--- a/src/main/java/umc/parasol/domain/notification/application/FirebaseCloudMessageService.java
+++ b/src/main/java/umc/parasol/domain/notification/application/FirebaseCloudMessageService.java
@@ -1,0 +1,39 @@
+package umc.parasol.domain.notification.application;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import umc.parasol.domain.member.domain.Member;
+import umc.parasol.domain.member.domain.repository.MemberRepository;
+import umc.parasol.global.config.security.token.UserPrincipal;
+
+@Component
+@RequiredArgsConstructor
+public class FirebaseCloudMessageService {
+    private final String API_URL = "https://fcm.googleapis.com/v1/projects/parasol-bcbf5/messages:send";
+    private final ObjectMapper objectMapper;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 동일 user가 기존 token과 입력된 token이 달라질 경우에만 업데이트하여 저장
+     * @param userPrincipal
+     * @param fcmToken
+     */
+    public boolean confirmFcmToken(UserPrincipal userPrincipal, String fcmToken) {
+        Member member = findMemberById(userPrincipal.getId());
+
+        // 현재 토큰과 달라질 경우에만 업데이트
+        if (!fcmToken.equals(member.getFcmToken())) {
+            member.updateFcmToken(fcmToken);
+            memberRepository.save(member);
+            return true;
+        }
+        return false;
+    }
+    private Member findMemberById(Long memerId) {
+        return memberRepository.findById(memerId).orElseThrow(
+                () -> new IllegalStateException("해당 member가 없습니다.")
+        );
+    }
+
+}

--- a/src/main/java/umc/parasol/domain/notification/domain/FcmMessage.java
+++ b/src/main/java/umc/parasol/domain/notification/domain/FcmMessage.java
@@ -1,0 +1,28 @@
+package umc.parasol.domain.notification.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@AllArgsConstructor
+@Getter
+public class FcmMessage {
+    private boolean validate_only;
+    private Message message;
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class Message {
+        private Notification notification;
+        private String token;
+    }
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class Notification {
+        private String title;
+        private String body;
+        private String image;
+    }
+}

--- a/src/main/java/umc/parasol/domain/notification/presentation/FcmController.java
+++ b/src/main/java/umc/parasol/domain/notification/presentation/FcmController.java
@@ -1,0 +1,42 @@
+package umc.parasol.domain.notification.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import umc.parasol.domain.notification.application.FirebaseCloudMessageService;
+import umc.parasol.global.config.security.token.CurrentUser;
+import umc.parasol.global.config.security.token.UserPrincipal;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/fcm")
+public class FcmController {
+    @Autowired
+    private FirebaseCloudMessageService fcmService;
+
+    /**
+     *
+     * @param userPrincipal
+     * @param fcmToken
+     * @return
+     */
+    @PostMapping("/update")
+    public ResponseEntity<?> updateFCMToken(@CurrentUser UserPrincipal userPrincipal, @RequestParam("token") String fcmToken) {
+        try {
+            boolean updated = fcmService.confirmFcmToken(userPrincipal, fcmToken);
+
+            if (updated) {
+                return ResponseEntity.ok("FCM 토큰이 업데이트되었습니다.");
+            } else {
+                return ResponseEntity.ok("기존 토큰과 동일합니다.");
+            }
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/umc/parasol/global/config/FcmConfig.java
+++ b/src/main/java/umc/parasol/global/config/FcmConfig.java
@@ -1,0 +1,43 @@
+package umc.parasol.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
+import com.google.firebase.messaging.ApsAlert;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import umc.parasol.domain.notification.domain.FcmMessage;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.io.InputStream;
+
+@Slf4j
+@Configuration
+public class FcmConfig {
+    @Value("${fcm.key.path}")
+    private String SERVICE_ACCOUNT_JSON;
+
+    @PostConstruct
+    public void init() {
+        try {
+            ClassPathResource resource = new ClassPathResource(SERVICE_ACCOUNT_JSON);
+            InputStream serviceAccount = resource.getInputStream();
+
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+
+            FirebaseApp.initializeApp(options);
+
+        } catch (IOException e) {
+            log.error("파이어베이스 서버와의 연결에 실패했습니다.");
+        }
+    }
+
+
+}


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] fcmToken API : 동일 user가 기존 token과 입력된 token이 달라질 경우에 새로운 fcmToken을 업데이트하여 저장하는 api입니다.
- [x] 푸시 알림 전송 기능


## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
[fcmToken update]
- 새로운 기기에서 앱을 설치하는 경우, 앱을 삭제했다가 다시 설치하는 경우, 앱 데이터를 지운 경우, fcm 토큰이 변경되기 때문에 이 때 변경된 토큰으로 업데이트하여 저장 될 수 있도록 하였습니다.
- notion에 api관련 설명 적어두었듯이, token을 requestbody로 입력 받게됩니다.

[푸시 알림 전송 기능]
- 일단 대여처리와 반납처리에서의 푸시알림 기능만을 고려하였습니다.
- Member객체에 fcmToken칼럼을 추가하였습니다.
- shopService.java : `rentalUmbrella`메서드와 `returnUmbrella`메서드에서 대여자에게 푸시 알림을 전송하는 `sendMessageTo`를 호출하도록 하였습니다.

- FirebaseCloudMessageService.java : `sendMessageTo`에서 `makeMessage` 메서드를 호출하여 메시지를 생성한 후, OkHttpClient를 이용하여 FCM 서버로 전송하도록 하였습니다.
- `makeMessage`에서는 targetToken, title, body 값을 매개변수로 받아서 FcmMessage 객체를 빌더 패턴을 이용하여 생성하였습니다.





## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
- 
