### PR TITLE
[FIX] : 여러장 업로드 및 삭제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,8 @@ dependencies {
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
-	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.2'
+//	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'com.github.devholic22:devholic-library:0.1.6'
 	implementation 'com.google.firebase:firebase-admin:8.0.0'  // 최신 버전 사용
 	implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.2.2'

--- a/src/main/java/umc/parasol/domain/image/application/ImageService.java
+++ b/src/main/java/umc/parasol/domain/image/application/ImageService.java
@@ -31,12 +31,11 @@ public class ImageService {
 
     public ApiResponse upload(List<MultipartFile> files, UserPrincipal user) throws Exception {
         List<ImageRes> uploadImages = new ArrayList<>();
-
+        Member owner = memberRepository.findById(user.getId())
+                .orElseThrow(() -> new IllegalStateException("해당 member가 없습니다."));
+        Shop targetShop = owner.getShop();
         for(MultipartFile file : files){
             String storedFileUrl = s3Uploader.outerUpload(file, "shop", user);
-            Member owner = memberRepository.findById(user.getId())
-                    .orElseThrow(() -> new IllegalStateException("해당 member가 없습니다."));
-            Shop targetShop = owner.getShop();
             Image storedImage = createImageEntity(storedFileUrl, targetShop.getId());
             uploadImages.add(new ImageRes(storedImage.getId(), storedImage.getUrl()));
         }

--- a/src/main/java/umc/parasol/domain/shop/presentation/ShopController.java
+++ b/src/main/java/umc/parasol/domain/shop/presentation/ShopController.java
@@ -14,6 +14,7 @@ import umc.parasol.global.config.security.token.UserPrincipal;
 import umc.parasol.global.payload.ApiResponse;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -78,19 +79,20 @@ public class ShopController {
     // 매장 사진 업로드
     @PostMapping(value = "/shop/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<?> imageUpload(@RequestParam(value = "image")
-                                         MultipartFile file, @CurrentUser UserPrincipal user) {
+                                         List<MultipartFile> files, @CurrentUser UserPrincipal user) {
         try {
-            return ResponseEntity.ok(imageService.upload(file, user));
+            return ResponseEntity.ok(imageService.upload(files, user));
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
     }
 
     // 매장 사진 삭제
-    @DeleteMapping("/shop/image/{id}")
-    public ResponseEntity<?> imageDelete(@PathVariable Long id, @CurrentUser UserPrincipal user) {
+    @DeleteMapping("/shop/image/{ids}")
+    public ResponseEntity<?> imageDelete(@PathVariable String ids, @CurrentUser UserPrincipal user) {
         try {
-            return ResponseEntity.ok(imageService.delete(id, user));
+            return ResponseEntity.ok(imageService.deleteMultiple(ids, user));
+
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 기존 매장 사진 업로드 api, 매장 사진 삭제 api의 url 그대로 사용할 수 있도록 수정하였습니다. 
- [x] 여러장 삭제의 경우, url에 콤마(,)로 구분하여 여러장 한번에 삭제가 가능하도록 구현하였습니다. (ex. /shop/image/2,3,5 : id가 2, 3, 5인 사진 한번에 삭제)

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- 


## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
- 
